### PR TITLE
update readme to match latest release in pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ MIT
 
 ## Changelog
 
+### 0.6.0
+
+- Make checking columns of multiple function parameters work also with positional arguments (thanks @latvanii)
+
 ### 0.5.0
 
 - Added `strict` parameter for `@df_in` and `@df_out`


### PR DESCRIPTION
I released the latest binaries to Pypi (0.6.0) with @latvanii 's update. This PR updates the README to match it.

I'm still hoping to be added as external collaborator to this repo as the project is written by me.