### PR TITLE
Update library dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,22 +14,24 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-    env:
-      PYTHON: ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: false
+
       - name: Install dependencies
         run: |
           poetry install
+
       - name: Lint with flake8, black, isort and mypy
         run: |
           poetry run isort --check .
@@ -37,11 +39,13 @@ jobs:
           poetry run flake8 .
           poetry run mypy .
           poetry run pydocstyle daffy/
+
       - name: Test with pytest
         run: |
           poetry run pytest --cov --cov-report=xml tests/
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
-          env_vars: PYTHON
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# JetBrains IDE (e.g., PyCharm)
+#  The .idea directory stores project settings specific to JetBrains IDEs.
+#  These settings are individual and generally not shared across different development environments.
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 23.11.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.1.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.982"
+    rev: v1.7.1
     hooks:
       - id: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,20 +24,20 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0.0"
-pandas = "^1.5.1"
+python = ">=3.8.1,<4.0.0"
+pandas = ">=1.5.1,<3.0.0"
 
 [tool.poetry.dev-dependencies]
-pytest = "^7.2.0"
-isort = "^5.10.1"
-black = "^22.10.0"
-flake8 = "^5.0.4"
-pre-commit = "^2.20.0"
-mypy = "^0.982"
-pytest-mock = "^3.10.0"
-pytest-cov = "^4.0.0"
-coverage = {extras = ["toml"], version = "^6.5.0"}
-pydocstyle = "^6.1.1"
+pytest = "^7.4.3"
+isort = "^5.12.0"
+black = "^23.11.0"
+flake8 = "^6.1.0"
+pre-commit = "^3.5.0"
+mypy = "^1.7.1"
+pytest-mock = "^3.12.0"
+pytest-cov = "^4.1.0"
+coverage = {extras = ["toml"], version = "^7.3.2"}
+pydocstyle = "^6.3.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
# What
In this PR, we update library dependencies to support pandas >=2.0.0 versions to be used with this library

# Why
It is best practice to have up-to-date dependencies since currently, the library does not support pandas >=2.0.0 and thus requires other projects to have pandas <2.0.0

# Good-to-know
Successfully managed to update dependencies with this fork that previously conflicted. Related to this Issue: https://github.com/fourkind/daffy/issues which I seem to be unable to link to this PR