### PR TITLE
Use Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 120
-extend-ignore = E203, W503
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,13 +32,11 @@ jobs:
         run: |
           poetry install
 
-      - name: Lint with flake8, black, isort and mypy
+      - name: Lint with Ruff and Mypy
         run: |
-          poetry run isort --check .
-          poetry run black --check .
-          poetry run flake8 .
+          poetry run ruff check --output-format=github .
+          poetry run ruff format --diff
           poetry run mypy .
-          poetry run pydocstyle daffy/
 
       - name: Test with pytest
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,9 @@
 repos:
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.9.1
     hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 23.11.0 # Replace by any tag/version: https://github.com/psf/black/tags
-    hooks:
-      - id: black
-        language_version: python3
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
-    hooks:
-      - id: mypy
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      - id: ruff-format

--- a/daffy/__init__.py
+++ b/daffy/__init__.py
@@ -5,6 +5,7 @@ output. It's hard to figure out quickly what these DataFrames contain. This libr
 annotate your functions so that they document themselves and that documentation is kept up-to-date by validating
 the input and output on runtime.
 """
+
 __version__ = "0.5.0"
 
 from .decorators import df_in  # noqa

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -1,4 +1,5 @@
 """Decorators for DAFFY DataFrame Column Validator."""
+
 import inspect
 import logging
 from functools import wraps
@@ -16,13 +17,13 @@ def _check_columns(df: pd.DataFrame, columns: ColumnsDef, strict: bool) -> None:
     if isinstance(columns, dict):
         for column, dtype in columns.items():
             assert column in df.columns, f"Column {column} missing from DataFrame. Got {_describe_pd(df)}"
-            assert (
-                df[column].dtype == dtype
-            ), f"Column {column} has wrong dtype. Was {df[column].dtype}, expected {dtype}"
+            assert df[column].dtype == dtype, (
+                f"Column {column} has wrong dtype. Was {df[column].dtype}, expected {dtype}"
+            )
     if strict:
-        assert len(df.columns) == len(
-            columns
-        ), f"DataFrame contained unexpected column(s): {', '.join(set(df.columns) - set(columns))}"
+        assert len(df.columns) == len(columns), (
+            f"DataFrame contained unexpected column(s): {', '.join(set(df.columns) - set(columns))}"
+        )
 
 
 def df_out(columns: Optional[ColumnsDef] = None, strict: bool = False) -> Callable:
@@ -84,9 +85,9 @@ def df_in(name: Optional[str] = None, columns: Optional[ColumnsDef] = None, stri
         @wraps(func)
         def wrapper(*args: str, **kwargs: Any) -> Any:
             df = _get_parameter(func, name, *args, **kwargs)
-            assert isinstance(
-                df, pd.DataFrame
-            ), f"Wrong parameter type. Expected Pandas DataFrame, got {type(df).__name__} instead."
+            assert isinstance(df, pd.DataFrame), (
+                f"Wrong parameter type. Expected Pandas DataFrame, got {type(df).__name__} instead."
+            )
             if columns:
                 _check_columns(df, columns, strict)
             return func(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ pytest-mock = "^3.12.0"
 pytest-cov = "^4.1.0"
 coverage = {extras = ["toml"], version = "^7.3.2"}
 pydocstyle = "^6.3.0"
+ruff = "^0.9.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -63,3 +64,10 @@ fail_under = 95
 
 [tool.black]
 line-length = 120
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["F", "E", "W", "I", "N"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,6 @@ pandas = ">=1.5.1,<3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
-isort = "^5.12.0"
-black = "^23.11.0"
-flake8 = "^6.1.0"
 pre-commit = "^3.5.0"
 mypy = "^1.7.1"
 pytest-mock = "^3.12.0"
@@ -50,10 +47,6 @@ ruff = "^0.9.1"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-
 [tool.coverage.run]
 branch = true
 source = ["daffy"]
@@ -61,9 +54,6 @@ source = ["daffy"]
 [tool.coverage.report]
 show_missing = true
 fail_under = 95
-
-[tool.black]
-line-length = 120
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pandas = ">=1.5.1,<3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
-pre-commit = "^3.5.0"
+pre-commit = "^4.0.0"
 mypy = "^1.7.1"
 pytest-mock = "^3.12.0"
 pytest-cov = "^4.1.0"


### PR DESCRIPTION
Use Ruff for formatting and linting. It's much faster and allows removing lots of other dependencies (flake8, pycodestyle, isort, black)..