### PR TITLE
avoid installing a separate version of ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,15 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.9.1
+  - repo: local
     hooks:
-      # Run the linter.
-      - id: ruff
-      # Run the formatter.
       - id: ruff-format
+        name: ruff format
+        entry: ruff format
+        language: system
+        types: [python]
+        require_serial: true
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check --fix
+        language: system
+        types: [python]
+        require_serial: true


### PR DESCRIPTION
avoid installing a separate version of ruff by commit hooks, use the one installed by uv