### PR TITLE
Upgrade dev dependencies

### DIFF
--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -34,7 +34,7 @@ def _find_dtype_mismatches(
     column_spec: Union[str, RegexColumnDef], df: DataFrameType, expected_dtype: Any, df_columns: List[str]
 ) -> List[Tuple[str, Any, Any]]:
     """Find dtype mismatches for a single column specification."""
-    mismatches = []
+    mismatches: List[Tuple[str, Any, Any]] = []
     if isinstance(column_spec, str):
         if column_spec in df_columns and df[column_spec].dtype != expected_dtype:
             mismatches.append((column_spec, df[column_spec].dtype, expected_dtype))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dev = [
     "pyrefly",
     "pytest-mock>=3.14.1",
     "pytest-cov>=6.0.0",
-    "coverage[toml]>=7.9.1",
+    "coverage[toml]>=7.10.6",
     "pydocstyle>=6.3.0",
-    "ruff>=0.12.0",
+    "ruff>=0.14.2",
     "pandas>=1.5.1,<3.0.0",
     "polars>=1.7.0",
 ]


### PR DESCRIPTION
## Summary
- Update ruff from 0.12.0 to 0.14.2
- Update coverage from 7.9.1 to 7.10.6 (latest version supporting Python 3.9)

## Details
This PR updates dev dependencies to their latest compatible versions. Note that coverage 7.11.0+ requires Python 3.10+, so we stay at the 7.10.x series to maintain Python 3.9 support as specified in the project's `requires-python = ">=3.9"`.

These are dev-only changes and don't affect library users since these dependencies are in the `[dependency-groups.dev]` section.

## Testing
- All 108 tests pass
- Ruff checks pass