### PR TITLE
Split dev dependencies and add Python 3.14 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: test
+name: CI
 
 on:
   push:
@@ -11,6 +11,7 @@ on:
 jobs:
   # Test on all Python versions with minimal dependencies
   test:
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,6 +39,7 @@ jobs:
 
   # Lint and type-check on latest Python only
   lint:
+    name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -64,6 +66,7 @@ jobs:
 
   # Coverage on latest Python only
   coverage:
+    name: Code Coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -95,6 +98,7 @@ jobs:
 
   # Test optional dependencies scenarios with pytest (always passes)
   test-optional-deps-pytest:
+    name: Optional Dependencies (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -119,6 +123,7 @@ jobs:
 
   # Test true isolation scenarios (manual script testing)
   test-isolation-scenarios:
+    name: Isolation ${{ matrix.scenario }} (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,8 @@ on:
       - master
 
 jobs:
-  # Standard tests with both pandas and polars
-  build:
+  # Test on all Python versions with minimal dependencies
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,9 +28,33 @@ jobs:
         run: |
           pip install uv
 
-      - name: Create virtual environment and install dependencies
+      - name: Install test dependencies
         run: |
-          uv sync
+          uv sync --group test
+
+      - name: Test with pytest
+        run: |
+          uv run pytest tests/
+
+  # Lint and type-check on latest Python only
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+
+      - name: Install uv
+        run: |
+          pip install uv
+
+      - name: Install dev dependencies
+        run: |
+          uv sync --group test --group dev
 
       - name: Lint with Ruff and Pyrefly
         run: |
@@ -38,7 +62,27 @@ jobs:
           uv run ruff format --diff
           uv run pyrefly check .
 
-      - name: Test with pytest
+  # Coverage on latest Python only
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+
+      - name: Install uv
+        run: |
+          pip install uv
+
+      - name: Install dev dependencies
+        run: |
+          uv sync --group test --group dev
+
+      - name: Test with coverage
         run: |
           uv run pytest --cov --cov-report=xml tests/
 
@@ -70,7 +114,7 @@ jobs:
 
       - name: Run optional dependencies tests with both libraries
         run: |
-          uv sync
+          uv sync --group test
           uv run pytest tests/test_optional_dependencies.py -v
 
   # Test true isolation scenarios (manual script testing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
 dev = [
     "ruff>=0.14.2",
     "pyrefly",
-    "coverage[toml]>=7.10.6",
+    "coverage[toml]>=7.11.0; python_version >= '3.10'",
     "pytest-cov>=6.0.0",
     "pre-commit>=4.0.0",
     "pydocstyle>=6.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,17 +34,22 @@ repository = "https://github.com/ThoughtWorksInc/daffy.git"
 documentation = "https://github.com/ThoughtWorksInc/daffy/blob/master/README.md"
 
 [dependency-groups]
-dev = [
+# Minimal dependencies for running tests - must support Python 3.9+
+test = [
     "pytest>=8.4.1",
-    "pre-commit>=4.0.0",
-    "pyrefly",
     "pytest-mock>=3.14.1",
-    "pytest-cov>=6.0.0",
-    "coverage[toml]>=7.10.6",
-    "pydocstyle>=6.3.0",
-    "ruff>=0.14.2",
     "pandas>=1.5.1,<3.0.0",
     "polars>=1.7.0",
+]
+
+# Development tools - can require latest Python
+dev = [
+    "ruff>=0.14.2",
+    "pyrefly",
+    "coverage[toml]>=7.10.6",
+    "pytest-cov>=6.0.0",
+    "pre-commit>=4.0.0",
+    "pydocstyle>=6.3.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Separate minimal test dependencies from development tools to enable supporting Python 3.9+ users while using modern dev tools that may drop support for older Python versions.

## Changes

### Dependency Groups
- **test**: Minimal deps for running tests (pytest, pandas, polars) - must support Python 3.9+
- **dev**: Linting, formatting, coverage, docs tools - can require latest Python

### CI Workflow
Split monolithic build job into focused jobs:
- **test**: Runs on Python 3.9-3.14 with `--group test` only
- **lint**: Runs on Python 3.13 with `--group test --group dev`
- **coverage**: Runs on Python 3.13 with `--group test --group dev`

### Python 3.14 Support
Added Python 3.14 to test matrix and package classifiers.

### Validation
Upgraded coverage from 7.10.6 to 7.11.0+ (requires Python 3.10+) with environment marker. This demonstrates that:
- Dev tools can be upgraded freely
- Python 3.9 tests still work (don't use dev group)
- Python 3.13 coverage job uses latest coverage

## Benefits

When dev tools drop Python 3.9 support in future releases:
- Just update version constraints in dev group
- Test jobs on Python 3.9 remain unaffected
- Lint/coverage jobs get latest tools on Python 3.13
- Library users on Python 3.9 are still supported