### PR TITLE
Enhance dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "increase"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "ruff"
+          - "pyrefly"
+          - "pytest*"
+          - "coverage*"
+          - "pre-commit"
+          - "pydocstyle"
+      test-dependencies:
+        patterns:
+          - "pandas"
+          - "polars"
+          - "pydantic"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Add `versioning-strategy: increase` for dev dependencies
- Group dev dependencies (ruff, pyrefly, pytest, coverage, pre-commit, pydocstyle)
- Group test dependencies (pandas, polars, pydantic)
- Add github-actions ecosystem with grouped updates

This reduces PR noise by grouping related updates together.