### PR TITLE
Pin dev/test dependencies for dependabot tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,21 +43,22 @@ issues = "https://github.com/vertti/daffy/issues"
 [dependency-groups]
 # Minimal dependencies for running tests - must support Python 3.9+
 test = [
-    "pytest>=8.4.1",
-    "pytest-mock>=3.14.1",
+    "pytest==8.4.2; python_version < '3.10'",
+    "pytest==9.0.2; python_version >= '3.10'",
+    "pytest-mock==3.15.1",
     "pandas>=1.5.1,<3.0.0",
     "polars>=1.7.0",
     "pydantic>=2.4.0",
 ]
 
-# Development tools - can require latest Python
+# Development tools - pinned for dependabot updates
 dev = [
-    "ruff>=0.14.2",
-    "pyrefly",
-    "coverage[toml]>=7.11.0; python_version >= '3.10'",
-    "pytest-cov>=6.0.0",
-    "pre-commit>=4.0.0",
-    "pydocstyle>=6.3.0",
+    "ruff==0.14.9",
+    "pyrefly==0.45.2",
+    "coverage[toml]==7.13.0; python_version >= '3.10'",
+    "pytest-cov==7.0.0",
+    "pre-commit==4.5.0; python_version >= '3.10'",
+    "pydocstyle==6.3.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Pin dev and test dependencies to exact versions so dependabot can create PRs when updates are available.

**Pinned dependencies:**
- pytest: 8.4.2 (py3.9) / 9.0.2 (py3.10+)
- pytest-mock: 3.15.1
- ruff: 0.14.9
- pyrefly: 0.45.2
- coverage: 7.13.0
- pytest-cov: 7.0.0
- pre-commit: 4.5.0
- pydocstyle: 6.3.0

**Kept loose constraints:**
- pandas, polars, pydantic (tested for compatibility ranges)

This enables dependabot to track and propose updates for dev dependencies.