### PR TITLE
docs: add comparison table, philosophy section, and recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,28 @@ Like type hints for DataFrames, Daffy helps you catch structural mismatches earl
 - Integrated logging for DataFrame structure inspection
 - Enhanced type annotations for improved IDE and type checker support
 
+## When to Use Daffy
+
+Different tools serve different needs. Here's how Daffy compares:
+
+| Use Case | Daffy | Pandera | Great Expectations |
+|----------|-------|---------|-------------------|
+| Function boundary guardrails | Primary focus | Possible via decorators | Not designed for this |
+| Quick column/type checks | Lightweight | Requires schema definitions | Requires Data Context setup |
+| Complex statistical checks | Limited | Many built-in | Extensive |
+| Pipeline/warehouse-wide QA | Not designed for this | Some support | Primary focus |
+
+## Philosophy
+
+- **Non-intrusive**: Just add decorators - no refactoring, no custom DataFrame types, no schema files
+- **Easy to adopt and remove**: Add Daffy in 30 seconds, remove it just as fast if needed
+- **Stay in-process**: No external stores, orchestrators, or infrastructure
+- **Minimal overhead**: Column validation is essentially free; pay for row validation only when you need it
+
 ## Documentation
 
 - [Usage Guide](https://github.com/vertti/daffy/blob/master/docs/usage.md) - Detailed usage instructions
+- [Recipes & Patterns](https://github.com/vertti/daffy/blob/master/docs/recipes.md) - Common usage patterns
 - [Development Guide](https://github.com/vertti/daffy/blob/master/docs/development.md) - Guide for contributing to Daffy
 - [Changelog](https://github.com/vertti/daffy/blob/master/CHANGELOG.md) - Version history and release notes
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,93 @@
+# Daffy Recipes & Patterns
+
+Practical examples showing Daffy in common scenarios.
+
+## ETL Pipeline Validation
+
+Validate DataFrames at each step of an ETL pipeline to catch issues early.
+
+```python
+import pandas as pd
+from daffy import df_in, df_out
+
+
+@df_out(columns={"product_id": "int64", "name": "object", "price": "float64", "category": "object"})
+def load_products(filepath: str) -> pd.DataFrame:
+    """Load product data from CSV."""
+    return pd.read_csv(filepath)
+
+
+@df_in(columns=["product_id", "name", "price", "category"])
+@df_out(columns=["product_id", "name", "price", "category", "price_tier"])
+def add_price_tier(df: pd.DataFrame) -> pd.DataFrame:
+    """Add price tier classification."""
+    df = df.copy()
+    df["price_tier"] = pd.cut(
+        df["price"],
+        bins=[0, 25, 100, float("inf")],
+        labels=["budget", "mid", "premium"]
+    )
+    return df
+
+
+@df_in(columns=["product_id", "name", "price", "category", "price_tier"])
+@df_out(columns=["category", "avg_price", "product_count"])
+def summarize_by_category(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate products by category."""
+    return df.groupby("category").agg(
+        avg_price=("price", "mean"),
+        product_count=("product_id", "count")
+    ).reset_index()
+
+
+def run_pipeline(input_path: str, output_path: str):
+    """Run the full ETL pipeline."""
+    products = load_products(input_path)
+    products_with_tier = add_price_tier(products)
+    summary = summarize_by_category(products_with_tier)
+    summary.to_csv(output_path, index=False)
+```
+
+If the CSV is missing a column or has wrong types, you'll get an error at the first step rather than a confusing failure downstream.
+
+## FastAPI Endpoint with DataFrame Validation
+
+Validate DataFrames before converting to JSON responses.
+
+```python
+import pandas as pd
+from fastapi import FastAPI, HTTPException
+from daffy import df_out
+
+app = FastAPI()
+
+# Simulated database
+PRODUCTS_DB = pd.DataFrame({
+    "id": [1, 2, 3],
+    "name": ["Widget", "Gadget", "Gizmo"],
+    "price": [19.99, 49.99, 29.99],
+    "in_stock": [True, False, True]
+})
+
+
+@df_out(columns={"id": "int64", "name": "object", "price": "float64", "in_stock": "bool"})
+def get_products_df(in_stock_only: bool = False) -> pd.DataFrame:
+    """Fetch products, optionally filtering to in-stock items."""
+    df = PRODUCTS_DB.copy()
+    if in_stock_only:
+        df = df[df["in_stock"]]
+    return df
+
+
+@app.get("/products")
+def list_products(in_stock_only: bool = False):
+    """API endpoint returning product list."""
+    try:
+        df = get_products_df(in_stock_only)
+        return df.to_dict(orient="records")
+    except AssertionError as e:
+        # Daffy validation failed - data integrity issue
+        raise HTTPException(status_code=500, detail="Data validation error")
+```
+
+The `@df_out` decorator ensures the DataFrame has the expected structure before it's serialized. If someone accidentally modifies `get_products_df` to return different columns, the validation catches it immediately.


### PR DESCRIPTION
## Summary

- Add "When to Use Daffy" comparison table showing how Daffy compares to Pandera and Great Expectations
- Add "Philosophy" section emphasizing non-intrusive, easy-to-adopt design
- Create `docs/recipes.md` with practical cookbook examples

## Changes

**README.md:**
- Comparison table after Key Features section
- Philosophy section with 4 bullet points
- Link to new recipes doc

**docs/recipes.md (new):**
- ETL Pipeline recipe: validation at each transformation step
- FastAPI Endpoint recipe: DataFrame validation before JSON serialization