### PR TITLE
Add nullable column validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.0
+
+### New Features
+
+- **Nullable column validation** - Validate that columns contain no null values
+  - Use rich column spec format: `{"column": {"nullable": False}}`
+  - Combines with dtype validation: `{"column": {"dtype": "float64", "nullable": False}}`
+  - Works with regex patterns: `{"r/Price_\\d+/": {"nullable": False}}`
+  - Default behavior unchanged (nullable=True, nulls allowed)
+
 ## 1.0.0
 
 ### Stable Release

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Like type hints for DataFrames, Daffy helps you catch structural mismatches earl
 - Validate DataFrame columns at function entry and exit points
 - Support regex patterns for matching column names (e.g., `"r/column_\d+/"`)
 - Check data types of columns
+- Validate columns contain no null values (`nullable=False`)
 - Control strictness of validation (allow or disallow extra columns)
 
 **Row Validation** (optional, requires Pydantic >= 2.4.0):

--- a/daffy/dataframe_types.py
+++ b/daffy/dataframe_types.py
@@ -88,23 +88,21 @@ def is_polars_dataframe(df: Any) -> TypeGuard[PolarsDataFrame]:
     return HAS_POLARS and pl is not None and isinstance(df, pl.DataFrame)
 
 
-def has_null_values(df: Any, column: str) -> tuple[bool, int]:
-    """Check if a DataFrame column has null values.
+def count_null_values(df: Any, column: str) -> int:
+    """Count null values in a DataFrame column.
 
     Args:
         df: DataFrame (pandas or polars)
         column: Column name to check
 
     Returns:
-        Tuple of (has_nulls, null_count)
+        Number of null values in the column
     """
     if is_pandas_dataframe(df):
-        null_count = int(df[column].isnull().sum())
-        return null_count > 0, null_count
+        return int(df[column].isnull().sum())
     elif is_polars_dataframe(df):
-        null_count = int(df[column].is_null().sum())
-        return null_count > 0, null_count
-    return False, 0
+        return int(df[column].is_null().sum())
+    return 0
 
 
 # Cache the types tuple at module level for efficiency

--- a/daffy/dataframe_types.py
+++ b/daffy/dataframe_types.py
@@ -88,5 +88,24 @@ def is_polars_dataframe(df: Any) -> TypeGuard[PolarsDataFrame]:
     return HAS_POLARS and pl is not None and isinstance(df, pl.DataFrame)
 
 
+def has_null_values(df: Any, column: str) -> tuple[bool, int]:
+    """Check if a DataFrame column has null values.
+
+    Args:
+        df: DataFrame (pandas or polars)
+        column: Column name to check
+
+    Returns:
+        Tuple of (has_nulls, null_count)
+    """
+    if is_pandas_dataframe(df):
+        null_count = int(df[column].isnull().sum())
+        return null_count > 0, null_count
+    elif is_polars_dataframe(df):
+        null_count = int(df[column].is_null().sum())
+        return null_count > 0, null_count
+    return False, 0
+
+
 # Cache the types tuple at module level for efficiency
 _DATAFRAME_TYPES = get_dataframe_types()

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Union
 
-from daffy.dataframe_types import DataFrameType
+from daffy.dataframe_types import DataFrameType, has_null_values
 from daffy.patterns import (
     RegexColumnDef,
     compile_regex_pattern,
@@ -20,6 +20,9 @@ from daffy.utils import describe_dataframe, format_param_context
 ColumnsList = Sequence[Union[str, RegexColumnDef]]
 ColumnsDict = dict[Union[str, RegexColumnDef], Any]
 ColumnsDef = Union[ColumnsList, ColumnsDict, None]
+
+# Rich column spec type: dict value can be {"dtype": ..., "nullable": ..., etc.}
+RichColumnSpec = dict[str, Any]
 
 
 def _find_missing_columns(column_spec: str | RegexColumnDef, df_columns: list[str]) -> list[str]:
@@ -49,6 +52,34 @@ def _find_dtype_mismatches(
     return mismatches
 
 
+def _find_nullable_violations(
+    column_spec: str | RegexColumnDef, df: DataFrameType, df_columns: list[str]
+) -> list[tuple[str, int]]:
+    """Find nullable violations for a column spec.
+
+    Returns:
+        List of (column_name, null_count) tuples for columns with null values.
+    """
+    violations: list[tuple[str, int]] = []
+    if isinstance(column_spec, str):
+        if column_spec in df_columns:
+            has_nulls, count = has_null_values(df, column_spec)
+            if has_nulls:
+                violations.append((column_spec, count))
+    elif is_regex_pattern(column_spec):
+        matches = match_column_with_regex(column_spec, df_columns)
+        for matched_col in matches:
+            has_nulls, count = has_null_values(df, matched_col)
+            if has_nulls:
+                violations.append((matched_col, count))
+    return violations
+
+
+def _is_rich_column_spec(value: Any) -> bool:
+    """Check if a column spec value is a rich spec dict (not just dtype string)."""
+    return isinstance(value, dict)
+
+
 def validate_dataframe(
     df: DataFrameType,
     columns: ColumnsList | ColumnsDict,
@@ -71,18 +102,32 @@ def validate_dataframe(
         AssertionError: If validation fails (missing columns, dtype mismatch, or extra columns in strict mode)
     """
     df_columns = list(df.columns)  # Cache the column list conversion
-    all_missing_columns = []
-    all_dtype_mismatches = []
-    all_matched_by_regex = set()
+    all_missing_columns: list[str] = []
+    all_dtype_mismatches: list[tuple[str, Any, Any]] = []
+    all_nullable_violations: list[tuple[str, int]] = []
+    all_matched_by_regex: set[str] = set()
 
     if isinstance(columns, dict):
-        for column, expected_dtype in columns.items():
+        for column, spec_value in columns.items():
             column_spec = (
                 compile_regex_pattern(column) if isinstance(column, str) and is_regex_string(column) else column
             )
             all_missing_columns.extend(_find_missing_columns(column_spec, df_columns))
-            all_dtype_mismatches.extend(_find_dtype_mismatches(column_spec, df, expected_dtype, df_columns))
             all_matched_by_regex.update(find_regex_matches(column_spec, df_columns))
+
+            # Handle both simple dtype specs ("float64") and rich specs ({"dtype": ..., "nullable": ...})
+            if _is_rich_column_spec(spec_value):
+                # Rich column spec: {"dtype": ..., "nullable": ..., etc.}
+                expected_dtype = spec_value.get("dtype")
+                nullable = spec_value.get("nullable", True)  # Default to True (allow nulls)
+
+                if expected_dtype is not None:
+                    all_dtype_mismatches.extend(_find_dtype_mismatches(column_spec, df, expected_dtype, df_columns))
+                if not nullable:
+                    all_nullable_violations.extend(_find_nullable_violations(column_spec, df, df_columns))
+            else:
+                # Simple dtype spec: just the dtype string
+                all_dtype_mismatches.extend(_find_dtype_mismatches(column_spec, df, spec_value, df_columns))
     else:
         processed_columns = compile_regex_patterns(columns)
         for column_spec in processed_columns:
@@ -100,6 +145,19 @@ def validate_dataframe(
             for col, was, expected in all_dtype_mismatches
         )
         raise AssertionError(mismatch_descriptions)
+
+    if all_nullable_violations:
+        if len(all_nullable_violations) == 1:
+            col, count = all_nullable_violations[0]
+            raise AssertionError(
+                f"Column '{col}'{param_info} contains {count} null value{'s' if count > 1 else ''} but nullable=False"
+            )
+        else:
+            violation_desc = ", ".join(
+                f"Column '{col}' contains {count} null value{'s' if count > 1 else ''}"
+                for col, count in all_nullable_violations
+            )
+            raise AssertionError(f"Nullable violations: {violation_desc}{param_info}")
 
     if strict:
         explicit_columns = {col for col in columns if isinstance(col, str)}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -135,6 +135,49 @@ If a column matches the regex pattern but has the wrong dtype, an error is raise
 AssertionError: Column Price_2 in function 'process_data' parameter 'df' has wrong dtype. Was float64, expected int64
 ```
 
+## Nullable Validation
+
+You can validate that columns contain no null values using the rich column spec format:
+
+```python
+@df_in(columns={"price": {"nullable": False}})
+def process_prices(df):
+    # price column must not contain any null/NaN values
+    ...
+```
+
+### Combining with Data Type Validation
+
+Nullable validation can be combined with dtype validation:
+
+```python
+@df_in(columns={"price": {"dtype": "float64", "nullable": False}})
+def process_prices(df):
+    # price must be float64 AND contain no nulls
+    ...
+```
+
+### With Regex Patterns
+
+Nullable validation works with regex patterns, applying to all matched columns:
+
+```python
+@df_in(columns={"r/Price_\\d+/": {"nullable": False}})
+def process_data(df):
+    # All columns matching Price_1, Price_2, etc. must not contain nulls
+    ...
+```
+
+### Default Behavior
+
+By default, `nullable=True`, meaning null values are allowed. This preserves backwards compatibility - existing code continues to work unchanged.
+
+If a column contains null values when `nullable=False`, an error is raised:
+
+```
+AssertionError: Column 'price' in function 'process_prices' parameter 'df' contains 3 null values but nullable=False
+```
+
 ## Strict Mode
 
 You can enable strict-mode for both `@df_in` and `@df_out`. This will raise an error if the DataFrame contains columns not defined in the annotation:

--- a/plan_v2.md
+++ b/plan_v2.md
@@ -1,0 +1,364 @@
+# plan.md (v2) — Combined roadmap (Daffy + Pandera-inspired)
+
+This plan merges the earlier roadmap with the new research. It keeps Daffy’s core principles:
+- **Low barrier to integrate/remove** (decorators on normal functions)
+- **No custom DataFrame types** (plain pandas DataFrames in user code)
+- Defaults remain unchanged unless users opt in via decorator flags or `pyproject.toml`.
+
+---
+
+## 1) What I think about the new research (quick take)
+
+I agree strongly with:
+- **Nullable validation**: high-value, easy, very mainstream.
+- **Uniqueness validation**: high-value, easy, very mainstream.
+- **Basic value checks** (small subset): high-value, moderate effort, worth doing.
+
+I’d treat these as “validation” (aligned with Daffy).
+
+I’m more cautious about:
+- **strict='filter'** and **drop_invalid=True**: both *transform* user data. They can still fit Daffy if they are **explicitly opt-in** and **default to non-invasive behavior** (copy or “validate only”).
+- **Ordered columns**: useful in exports/CSV APIs, but less common than nullable/unique. Still easy enough to include.
+
+I’d keep **schema inference** as a later “nice-to-have”.
+
+---
+
+## 2) Recommended “next 5” to implement (value vs effort)
+
+### 1. Nullable column validation (NEW)
+- Opt-in per-column: `nullable: bool` (default True).
+- Project default optional (`[tool.daffy] nullable_default = true`).
+
+### 2. Uniqueness validation (NEW)
+- `unique=["col"]` and composite `unique=[["a","b"]]`.
+
+### 3. Optional columns (NEW)
+- Per-column `required: bool` or per-decorator `optional=[...]` (choose one unified approach; see below).
+
+### 4. Basic vectorized value checks (NEW)
+- Minimal ops: `gt/ge/lt/le/isin/notnull/str_regex/between`.
+
+### 5. Validation modes + lazy aggregation (NEW)
+- `validation_mode = "error" | "warn" | "off"` + `lazy=true|false`.
+
+**Near-next (phase 2 / optional, more “transformative”):**
+- `strict="filter"` (drop extra cols) — opt-in, and ideally on a copy.
+- `coerce=True` (type coercion) — opt-in, on a copy by default.
+- `drop_invalid=True` (row filtering) — opt-in, and safest if it returns a filtered df (or filters on a copy).
+
+---
+
+## 3) Public API proposal (backwards-compatible)
+
+### 3.1 Keep current `columns=` formats working
+Daffy currently supports:
+- `columns=["Brand", "Price"]`
+- `columns={"Brand": "object", "Price": "int64"}`
+
+This must continue to work unchanged.
+
+### 3.2 Extend dict values to allow rich column specs
+Allow:
+```python
+columns={
+  "price": {"dtype": "float64", "nullable": False, "checks": {"gt": 0}},
+  "status": {"dtype": "object", "checks": {"isin": ["active","pending","closed"]}},
+  "optional_col": {"dtype": "int64", "required": False},
+}
+```
+
+Rules:
+- If value is a **string** → dtype-only (existing behavior).
+- If value is a **dict** → supports:
+  - `dtype: str | None`
+  - `nullable: bool` (default: True)
+  - `required: bool` (default: True)
+  - `checks: dict[str, object]` (optional)
+
+This keeps all the “extra flags” in one place (matches the new research’s suggested style).
+
+### 3.3 Decorator-level args (for cross-column features)
+Add to `df_in/df_out` (all `None` = “use config default”):
+- `strict: bool | Literal["filter"] | None`
+- `ordered: bool | None` *(only meaningful when columns are list or dict order is intended)*
+- `unique: list[str] | list[list[str]] | None`
+- `lazy: bool | None`
+- `on_error: Literal["error","warn","off"] | None`
+- (optional later) `coerce: bool | None`, `coerce_copy: bool | None`
+- (optional later) `drop_invalid: bool | None`, `drop_invalid_copy: bool | None`
+
+---
+
+## 4) `pyproject.toml` config additions
+
+Extend `[tool.daffy]`:
+
+```toml
+[tool.daffy]
+# existing
+strict = false
+
+# new (phase 1)
+validation_mode = "error"   # "error" | "warn" | "off"
+lazy = false
+nullable_default = true
+checks_max_errors = 5
+unique_max_errors = 5
+ordered = false
+
+# optional later (phase 2)
+coerce = false
+coerce_copy = true
+strict_filter_copy = true
+drop_invalid = false
+drop_invalid_copy = true
+
+# existing
+row_validation_max_errors = 5
+row_validation_convert_nans = true
+```
+
+Decorator args always override config if provided.
+
+---
+
+## 5) Internal refactor (do first)
+
+### 5.1 Central validation pipeline
+Create one internal function used by both `df_in` and `df_out`:
+
+```python
+def validate_df(
+    df,
+    *,
+    columns_spec,
+    strict,
+    ordered,
+    unique,
+    lazy,
+    context,
+    cfg,
+):
+    # returns (maybe_transformed_df, issues)
+```
+
+### 5.2 Issue and error types
+Introduce:
+- `Issue(code, message, details={...})`
+- `DaffyValidationError(issues, context)` (subclass `AssertionError`)
+
+### 5.3 Handling modes: error/warn/off
+Decorator wrapper should:
+- If mode == off: skip validation, call function.
+- Else run validation and:
+  - warn: `warnings.warn(msg, stacklevel=3)`
+  - error: raise
+
+---
+
+## 6) Feature specs + implementation notes
+
+## 6.1 Nullable validation (phase 1)
+
+### Usage
+```python
+@df_in(columns={"price": {"dtype": "float64", "nullable": False}})
+def f(df): ...
+```
+
+### Behavior
+- If nullable is False → fail if any `isna()` in that column.
+- For regex keys, apply to all matched columns.
+- Respect `required=False`: if column missing, skip nullable check.
+
+### Implementation
+- After existence check (and optional coercion if ever enabled), compute:
+  - `na_count = df[col].isna().sum()`
+  - if `na_count > 0` → issue.
+
+### Error message suggestion
+- `Column 'price' in function 'f' parameter 'df' contains 3 null values but nullable=False`
+
+Tests:
+- nullable false with NaN → error
+- nullable true with NaN → ok
+- missing optional column with nullable false → ok
+
+---
+
+## 6.2 Uniqueness validation (phase 1)
+
+### Usage
+```python
+@df_in(columns=["user_id"], unique=["user_id"])
+def f(df): ...
+
+@df_in(unique=[["order_id","line_item"]])
+def g(df): ...
+```
+
+### Behavior
+- For each uniqueness spec:
+  - if any duplicates → fail
+- Report up to `unique_max_errors` duplicate keys or row indices.
+
+### Implementation
+- `dupes = df.duplicated(subset=subset_cols, keep=False)`
+- if any: capture indices or example duplicate values.
+
+Tests:
+- simple unique column
+- composite unique
+- works with strict and ordered flags
+
+---
+
+## 6.3 Optional columns (phase 1)
+
+Prefer **one** approach:
+- **Option A (recommended):** per-column `required=False` (inside rich column spec)
+- Option B: decorator `optional=[...]`
+
+**Recommendation:** Option A, because it composes naturally with `nullable` and `checks`.
+
+### Usage
+```python
+@df_in(columns={
+  "discount": {"dtype": "float64", "required": False},
+})
+def f(df): ...
+```
+
+Tests:
+- required=False and missing → ok
+- required=True and missing → error
+- present but dtype wrong → error
+
+---
+
+## 6.4 Basic vectorized checks (phase 1)
+
+### Usage
+```python
+@df_in(columns={
+  "price": {"dtype": "float64", "checks": {"gt": 0}},
+  "status": {"dtype": "object", "checks": {"isin": ["active","pending","closed"]}},
+  "name": {"dtype": "object", "checks": {"str_regex": r"^[A-Za-z].+"}},
+})
+def f(df): ...
+```
+
+### Supported ops (v1)
+- `gt`, `ge`, `lt`, `le`, `eq`, `ne`
+- `between`: (lo, hi) inclusive
+- `isin`: list/set
+- `notnull`: true
+- `str_regex`: pattern
+
+### Implementation
+- For each column + checks:
+  - compute boolean pass mask vectorized
+  - if any failures, record up to `checks_max_errors` failing indices
+- Regex column keys expand to multiple columns.
+
+Tests:
+- each op + max errors
+- checks skipped if column is missing and `required=False`
+- checks after dtype validation (or before, but dtype mismatch should be reported clearly)
+
+---
+
+## 6.5 Lazy aggregation + validation modes (phase 1)
+
+### Usage
+```python
+@df_in(columns=[...], lazy=True, on_error="warn")
+def f(df): ...
+```
+
+### Behavior
+- `lazy=False` default: fail-fast (but keep current “missing columns: [...]” aggregation).
+- `lazy=True`: accumulate issues from:
+  - missing columns
+  - dtype mismatches
+  - nullable violations
+  - uniqueness violations
+  - vectorized checks
+  - row validation summary (single issue)
+
+### Implementation
+- All validators return list[Issue].
+- If lazy: return all issues; else raise on first (or return first).
+
+---
+
+## 7) Transformative features (phase 2) — only if you want them
+
+These are useful but more “Pandera-like” in that they can modify data.
+
+### 7.1 strict="filter"
+- If strict is `"filter"`, drop extra columns.
+- Default should remain strict=True/False behavior.
+- Best practice: apply on a copy (config `strict_filter_copy=true`).
+
+### 7.2 coerce=True
+- Attempt `astype` conversion for columns with dtype.
+- Do on copy by default.
+
+### 7.3 drop_invalid=True (row_validator)
+- If enabled, filter out rows that fail Pydantic validation.
+- Warning: changes semantics; document clearly.
+- Safest implementation: filter on copy and log/warn about drop count.
+
+---
+
+## 8) Milestones (implementation order)
+
+### Milestone 1 — Refactor (must)
+- [ ] `Issue`, `ValidationContext`, `DaffyValidationError`
+- [ ] central `validate_df` pipeline
+- [ ] mode handling (error/warn/off) + lazy
+
+### Milestone 2 — Nullable + Optional + Checks (high value)
+- [ ] rich column spec parsing
+- [ ] required/nullable logic
+- [ ] minimal vectorized checks
+
+### Milestone 3 — Uniqueness + Ordered
+- [ ] `unique` validation
+- [ ] `ordered=True` validation for list / ordered dict keys
+
+### Milestone 4 — (optional) strict="filter", coerce
+- [ ] implement and document as transformative opt-ins
+
+### Milestone 5 — (optional) drop_invalid + schema inference
+- [ ] only if demand appears
+
+---
+
+## 9) Testing checklist (pytest)
+
+- Backwards compatibility:
+  - old `columns=[...]` and `columns={col: dtype}` behave identically
+- New features:
+  - nullable false
+  - required false
+  - checks ops
+  - unique and composite unique
+  - ordered
+  - lazy aggregation
+  - warn/off modes
+
+---
+
+## 10) Acceptance criteria
+
+- No breaking changes to existing Daffy usage patterns.
+- All new behaviors are opt-in or default-configurable.
+- Error messages still include:
+  - function name
+  - input vs output (parameter vs return)
+  - parameter name when applicable
+- Transformative behaviors (filter/coerce/drop) are clearly labeled and off by default.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "1.0.2"
+version = "1.1.0"
 description = "Function decorators for Pandas and Polars DataFrame validation - columns, data types, and row-level validation with Pydantic"
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },

--- a/tests/test_null_detection.py
+++ b/tests/test_null_detection.py
@@ -3,52 +3,38 @@
 import pandas as pd
 import polars as pl
 
-from daffy.dataframe_types import has_null_values
+from daffy.dataframe_types import count_null_values
 
 
-class TestHasNullValuesPandas:
+class TestCountNullValuesPandas:
     def test_detects_nulls_in_pandas(self) -> None:
         df = pd.DataFrame({"a": [1.0, None, 3.0]})
-        has_nulls, count = has_null_values(df, "a")
-        assert has_nulls is True
-        assert count == 1
+        assert count_null_values(df, "a") == 1
 
     def test_no_nulls_in_pandas(self) -> None:
         df = pd.DataFrame({"a": [1.0, 2.0, 3.0]})
-        has_nulls, count = has_null_values(df, "a")
-        assert has_nulls is False
-        assert count == 0
+        assert count_null_values(df, "a") == 0
 
     def test_multiple_nulls_in_pandas(self) -> None:
         df = pd.DataFrame({"a": [None, None, None, 1.0]})
-        has_nulls, count = has_null_values(df, "a")
-        assert has_nulls is True
-        assert count == 3
+        assert count_null_values(df, "a") == 3
 
     def test_nan_in_pandas(self) -> None:
         import numpy as np
 
         df = pd.DataFrame({"a": [1.0, np.nan, 3.0]})
-        has_nulls, count = has_null_values(df, "a")
-        assert has_nulls is True
-        assert count == 1
+        assert count_null_values(df, "a") == 1
 
 
-class TestHasNullValuesPolars:
+class TestCountNullValuesPolars:
     def test_detects_nulls_in_polars(self) -> None:
         df = pl.DataFrame({"a": [1.0, None, 3.0]})
-        has_nulls, count = has_null_values(df, "a")
-        assert has_nulls is True
-        assert count == 1
+        assert count_null_values(df, "a") == 1
 
     def test_no_nulls_in_polars(self) -> None:
         df = pl.DataFrame({"a": [1.0, 2.0, 3.0]})
-        has_nulls, count = has_null_values(df, "a")
-        assert has_nulls is False
-        assert count == 0
+        assert count_null_values(df, "a") == 0
 
     def test_multiple_nulls_in_polars(self) -> None:
         df = pl.DataFrame({"a": [None, None, None, 1.0]})
-        has_nulls, count = has_null_values(df, "a")
-        assert has_nulls is True
-        assert count == 3
+        assert count_null_values(df, "a") == 3

--- a/tests/test_null_detection.py
+++ b/tests/test_null_detection.py
@@ -1,0 +1,54 @@
+"""Tests for null value detection utility."""
+
+import pandas as pd
+import polars as pl
+
+from daffy.dataframe_types import has_null_values
+
+
+class TestHasNullValuesPandas:
+    def test_detects_nulls_in_pandas(self) -> None:
+        df = pd.DataFrame({"a": [1.0, None, 3.0]})
+        has_nulls, count = has_null_values(df, "a")
+        assert has_nulls is True
+        assert count == 1
+
+    def test_no_nulls_in_pandas(self) -> None:
+        df = pd.DataFrame({"a": [1.0, 2.0, 3.0]})
+        has_nulls, count = has_null_values(df, "a")
+        assert has_nulls is False
+        assert count == 0
+
+    def test_multiple_nulls_in_pandas(self) -> None:
+        df = pd.DataFrame({"a": [None, None, None, 1.0]})
+        has_nulls, count = has_null_values(df, "a")
+        assert has_nulls is True
+        assert count == 3
+
+    def test_nan_in_pandas(self) -> None:
+        import numpy as np
+
+        df = pd.DataFrame({"a": [1.0, np.nan, 3.0]})
+        has_nulls, count = has_null_values(df, "a")
+        assert has_nulls is True
+        assert count == 1
+
+
+class TestHasNullValuesPolars:
+    def test_detects_nulls_in_polars(self) -> None:
+        df = pl.DataFrame({"a": [1.0, None, 3.0]})
+        has_nulls, count = has_null_values(df, "a")
+        assert has_nulls is True
+        assert count == 1
+
+    def test_no_nulls_in_polars(self) -> None:
+        df = pl.DataFrame({"a": [1.0, 2.0, 3.0]})
+        has_nulls, count = has_null_values(df, "a")
+        assert has_nulls is False
+        assert count == 0
+
+    def test_multiple_nulls_in_polars(self) -> None:
+        df = pl.DataFrame({"a": [None, None, None, 1.0]})
+        has_nulls, count = has_null_values(df, "a")
+        assert has_nulls is True
+        assert count == 3

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -43,3 +43,43 @@ class TestNullableBasic:
         df = pl.DataFrame({"price": [1.0, 2.0, 3.0]})
         result = f(df)
         assert len(result) == 3
+
+
+class TestNullableWithDtype:
+    def test_nullable_with_dtype_pandas(self) -> None:
+        @df_in(columns={"price": {"dtype": "float64", "nullable": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # Should check both dtype AND nullable
+        df = pd.DataFrame({"price": [1.0, None, 3.0]})
+        with pytest.raises(AssertionError, match="null value"):
+            f(df)
+
+    def test_nullable_with_dtype_polars(self) -> None:
+        @df_in(columns={"price": {"dtype": pl.Float64, "nullable": False}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"price": [1.0, None, 3.0]})
+        with pytest.raises(AssertionError, match="null value"):
+            f(df)
+
+    def test_dtype_only_rich_spec_pandas(self) -> None:
+        @df_in(columns={"price": {"dtype": "float64"}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # Should still validate dtype
+        df = pd.DataFrame({"price": [1.0, 2.0, 3.0]})
+        result = f(df)
+        assert len(result) == 3
+
+    def test_dtype_mismatch_rich_spec(self) -> None:
+        @df_in(columns={"price": {"dtype": "int64"}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"price": [1.0, 2.0, 3.0]})  # float64, not int64
+        with pytest.raises(AssertionError, match="wrong dtype"):
+            f(df)

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -4,7 +4,7 @@ import pandas as pd
 import polars as pl
 import pytest
 
-from daffy import df_in
+from daffy import df_in, df_out
 
 
 class TestNullableBasic:
@@ -172,3 +172,37 @@ class TestNullableWithRegex:
         df = pd.DataFrame({"Price_1": [1.0, None], "Price_2": [2.0, 3.0]})
         with pytest.raises(AssertionError, match="null value"):
             f(df)
+
+
+class TestNullableDfOut:
+    def test_df_out_nullable_false_pandas(self) -> None:
+        @df_out(columns={"price": {"nullable": False}})
+        def f() -> pd.DataFrame:
+            return pd.DataFrame({"price": [1.0, None, 3.0]})
+
+        with pytest.raises(AssertionError, match="return value"):
+            f()
+
+    def test_df_out_nullable_false_polars(self) -> None:
+        @df_out(columns={"price": {"nullable": False}})
+        def f() -> pl.DataFrame:
+            return pl.DataFrame({"price": [1.0, None, 3.0]})
+
+        with pytest.raises(AssertionError, match="return value"):
+            f()
+
+    def test_df_out_nullable_passes(self) -> None:
+        @df_out(columns={"price": {"nullable": False}})
+        def f() -> pd.DataFrame:
+            return pd.DataFrame({"price": [1.0, 2.0, 3.0]})
+
+        result = f()
+        assert len(result) == 3
+
+    def test_df_out_with_dtype_and_nullable(self) -> None:
+        @df_out(columns={"price": {"dtype": "float64", "nullable": False}})
+        def f() -> pd.DataFrame:
+            return pd.DataFrame({"price": [1.0, None, 3.0]})
+
+        with pytest.raises(AssertionError, match="null value"):
+            f()

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -1,0 +1,45 @@
+"""Tests for nullable column validation."""
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from daffy import df_in
+
+
+class TestNullableBasic:
+    def test_nullable_false_rejects_nulls_pandas(self) -> None:
+        @df_in(columns={"price": {"nullable": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"price": [1.0, None, 3.0]})
+        with pytest.raises(AssertionError, match="null value"):
+            f(df)
+
+    def test_nullable_false_rejects_nulls_polars(self) -> None:
+        @df_in(columns={"price": {"nullable": False}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"price": [1.0, None, 3.0]})
+        with pytest.raises(AssertionError, match="null value"):
+            f(df)
+
+    def test_nullable_false_passes_without_nulls_pandas(self) -> None:
+        @df_in(columns={"price": {"nullable": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"price": [1.0, 2.0, 3.0]})
+        result = f(df)
+        assert len(result) == 3
+
+    def test_nullable_false_passes_without_nulls_polars(self) -> None:
+        @df_in(columns={"price": {"nullable": False}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"price": [1.0, 2.0, 3.0]})
+        result = f(df)
+        assert len(result) == 3

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -83,3 +83,42 @@ class TestNullableWithDtype:
         df = pd.DataFrame({"price": [1.0, 2.0, 3.0]})  # float64, not int64
         with pytest.raises(AssertionError, match="wrong dtype"):
             f(df)
+
+
+class TestNullableDefault:
+    def test_nullable_default_allows_nulls_pandas(self) -> None:
+        # When nullable is not specified, it defaults to True (allow nulls)
+        @df_in(columns={"price": {"dtype": "float64"}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"price": [1.0, None, 3.0]})
+        result = f(df)  # Should NOT raise
+        assert len(result) == 3
+
+    def test_nullable_default_allows_nulls_polars(self) -> None:
+        @df_in(columns={"price": {"dtype": pl.Float64}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"price": [1.0, None, 3.0]})
+        result = f(df)  # Should NOT raise
+        assert len(result) == 3
+
+    def test_nullable_true_explicit_pandas(self) -> None:
+        @df_in(columns={"price": {"nullable": True}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"price": [1.0, None, 3.0]})
+        result = f(df)  # Should NOT raise
+        assert len(result) == 3
+
+    def test_nullable_true_explicit_polars(self) -> None:
+        @df_in(columns={"price": {"nullable": True}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"price": [1.0, None, 3.0]})
+        result = f(df)  # Should NOT raise
+        assert len(result) == 3

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -122,3 +122,53 @@ class TestNullableDefault:
         df = pl.DataFrame({"price": [1.0, None, 3.0]})
         result = f(df)  # Should NOT raise
         assert len(result) == 3
+
+
+class TestNullableWithRegex:
+    def test_regex_pattern_nullable_false_pandas(self) -> None:
+        @df_in(columns={"r/Price_\\d+/": {"nullable": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # Price_1 has nulls, should fail
+        df = pd.DataFrame({"Price_1": [1.0, None], "Price_2": [2.0, 3.0]})
+        with pytest.raises(AssertionError, match="Price_1"):
+            f(df)
+
+    def test_regex_pattern_nullable_false_polars(self) -> None:
+        @df_in(columns={"r/Price_\\d+/": {"nullable": False}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"Price_1": [1.0, None], "Price_2": [2.0, 3.0]})
+        with pytest.raises(AssertionError, match="Price_1"):
+            f(df)
+
+    def test_regex_pattern_all_columns_checked(self) -> None:
+        @df_in(columns={"r/Price_\\d+/": {"nullable": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # Both columns have nulls - should report both
+        df = pd.DataFrame({"Price_1": [1.0, None], "Price_2": [None, 3.0]})
+        with pytest.raises(AssertionError, match="Nullable violations"):
+            f(df)
+
+    def test_regex_pattern_nullable_passes(self) -> None:
+        @df_in(columns={"r/Price_\\d+/": {"nullable": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # No nulls - should pass
+        df = pd.DataFrame({"Price_1": [1.0, 2.0], "Price_2": [2.0, 3.0]})
+        result = f(df)
+        assert len(result) == 2
+
+    def test_regex_with_dtype_and_nullable(self) -> None:
+        @df_in(columns={"r/Price_\\d+/": {"dtype": "float64", "nullable": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"Price_1": [1.0, None], "Price_2": [2.0, 3.0]})
+        with pytest.raises(AssertionError, match="null value"):
+            f(df)


### PR DESCRIPTION
## Summary

- Add nullable column validation using rich column spec format
- Columns can opt-out of allowing nulls via `{"column": {"nullable": False}}`
- Works with dtype validation, regex patterns, and both `@df_in`/`@df_out`
- Default behavior unchanged (nullable=True) for backwards compatibility
- Bump version to 1.1.0

## Usage

```python
@df_in(columns={"price": {"dtype": "float64", "nullable": False}})
def process(df):
    return df
```

## Changes

- `daffy/dataframe_types.py`: Add `has_null_values()` utility
- `daffy/validation.py`: Add rich column spec support with nullable validation
- New test file `tests/test_nullable.py` with 29 tests
- Documentation updates (README, usage.md, CHANGELOG)