### PR TITLE
Add unique column validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.2.0
+
+### New Features
+
+- **Uniqueness column validation** - Validate that columns contain only unique values
+  - Use rich column spec format: `{"column": {"unique": True}}`
+  - Combines with dtype and nullable: `{"column": {"dtype": "int64", "unique": True, "nullable": False}}`
+  - Works with regex patterns: `{"r/ID_\\d+/": {"unique": True}}`
+  - Default behavior unchanged (unique=False, duplicates allowed)
+
 ## 1.1.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Like type hints for DataFrames, Daffy helps you catch structural mismatches earl
 - Support regex patterns for matching column names (e.g., `"r/column_\d+/"`)
 - Check data types of columns
 - Validate columns contain no null values (`nullable=False`)
+- Validate columns contain only unique values (`unique=True`)
 - Control strictness of validation (allow or disallow extra columns)
 
 **Row Validation** (optional, requires Pydantic >= 2.4.0):

--- a/daffy/dataframe_types.py
+++ b/daffy/dataframe_types.py
@@ -105,5 +105,23 @@ def count_null_values(df: Any, column: str) -> int:
     return 0
 
 
+def count_duplicate_values(df: Any, column: str) -> int:
+    """Count duplicate values in a DataFrame column.
+
+    Args:
+        df: DataFrame (pandas or polars)
+        column: Column name to check
+
+    Returns:
+        Number of duplicate values in the column (excludes first occurrence)
+    """
+    if is_pandas_dataframe(df):
+        return int(df[column].duplicated().sum())
+    elif is_polars_dataframe(df):
+        # polars is_duplicated() marks ALL occurrences, use n_rows - n_unique instead
+        return len(df) - df[column].n_unique()
+    return 0
+
+
 # Cache the types tuple at module level for efficiency
 _DATAFRAME_TYPES = get_dataframe_types()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -178,6 +178,49 @@ If a column contains null values when `nullable=False`, an error is raised:
 AssertionError: Column 'price' in function 'process_prices' parameter 'df' contains 3 null values but nullable=False
 ```
 
+## Uniqueness Validation
+
+You can validate that columns contain only unique values using the rich column spec format:
+
+```python
+@df_in(columns={"user_id": {"unique": True}})
+def process_users(df):
+    # user_id column must not contain any duplicate values
+    ...
+```
+
+### Combining with Other Validations
+
+Uniqueness validation can be combined with dtype and nullable validation:
+
+```python
+@df_in(columns={"user_id": {"dtype": "int64", "unique": True, "nullable": False}})
+def process_users(df):
+    # user_id must be int64, contain no nulls, AND have no duplicates
+    ...
+```
+
+### With Regex Patterns
+
+Uniqueness validation works with regex patterns, applying to all matched columns:
+
+```python
+@df_in(columns={"r/ID_\\d+/": {"unique": True}})
+def process_data(df):
+    # All columns matching ID_1, ID_2, etc. must have unique values
+    ...
+```
+
+### Default Behavior
+
+By default, `unique=False`, meaning duplicate values are allowed. This preserves backwards compatibility - existing code continues to work unchanged.
+
+If a column contains duplicate values when `unique=True`, an error is raised:
+
+```
+AssertionError: Column 'user_id' in function 'process_users' parameter 'df' contains 5 duplicate values but unique=True
+```
+
 ## Strict Mode
 
 You can enable strict-mode for both `@df_in` and `@df_out`. This will raise an error if the DataFrame contains columns not defined in the annotation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "1.1.0"
+version = "1.2.0"
 description = "Function decorators for Pandas and Polars DataFrame validation - columns, data types, and row-level validation with Pydantic"
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },

--- a/tests/test_duplicate_detection.py
+++ b/tests/test_duplicate_detection.py
@@ -1,0 +1,34 @@
+"""Tests for duplicate value detection utility."""
+
+import pandas as pd
+import polars as pl
+
+from daffy.dataframe_types import count_duplicate_values
+
+
+class TestCountDuplicateValuesPandas:
+    def test_detects_duplicates_in_pandas(self) -> None:
+        df = pd.DataFrame({"a": [1, 2, 2, 3]})
+        assert count_duplicate_values(df, "a") == 1
+
+    def test_no_duplicates_in_pandas(self) -> None:
+        df = pd.DataFrame({"a": [1, 2, 3, 4]})
+        assert count_duplicate_values(df, "a") == 0
+
+    def test_multiple_duplicates_in_pandas(self) -> None:
+        df = pd.DataFrame({"a": [1, 1, 1, 2, 2]})
+        assert count_duplicate_values(df, "a") == 3
+
+
+class TestCountDuplicateValuesPolars:
+    def test_detects_duplicates_in_polars(self) -> None:
+        df = pl.DataFrame({"a": [1, 2, 2, 3]})
+        assert count_duplicate_values(df, "a") == 1
+
+    def test_no_duplicates_in_polars(self) -> None:
+        df = pl.DataFrame({"a": [1, 2, 3, 4]})
+        assert count_duplicate_values(df, "a") == 0
+
+    def test_multiple_duplicates_in_polars(self) -> None:
+        df = pl.DataFrame({"a": [1, 1, 1, 2, 2]})
+        assert count_duplicate_values(df, "a") == 3

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -151,7 +151,7 @@ class TestNullableWithRegex:
 
         # Both columns have nulls - should report both
         df = pd.DataFrame({"Price_1": [1.0, None], "Price_2": [None, 3.0]})
-        with pytest.raises(AssertionError, match="Nullable violations"):
+        with pytest.raises(AssertionError, match="Null violations"):
             f(df)
 
     def test_regex_pattern_nullable_passes(self) -> None:

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -1,0 +1,81 @@
+"""Tests for unique column validation."""
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from daffy import df_in
+
+
+class TestUniqueBasic:
+    def test_unique_true_rejects_duplicates_pandas(self) -> None:
+        @df_in(columns={"user_id": {"unique": True}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"user_id": [1, 2, 2, 3]})
+        with pytest.raises(AssertionError, match="duplicate value"):
+            f(df)
+
+    def test_unique_true_rejects_duplicates_polars(self) -> None:
+        @df_in(columns={"user_id": {"unique": True}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"user_id": [1, 2, 2, 3]})
+        with pytest.raises(AssertionError, match="duplicate value"):
+            f(df)
+
+    def test_unique_true_passes_when_all_unique_pandas(self) -> None:
+        @df_in(columns={"user_id": {"unique": True}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"user_id": [1, 2, 3, 4]})
+        result = f(df)
+        assert len(result) == 4
+
+    def test_unique_true_passes_when_all_unique_polars(self) -> None:
+        @df_in(columns={"user_id": {"unique": True}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"user_id": [1, 2, 3, 4]})
+        result = f(df)
+        assert len(result) == 4
+
+    def test_default_allows_duplicates_pandas(self) -> None:
+        @df_in(columns={"user_id": {"dtype": "int64"}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"user_id": [1, 2, 2, 3]})
+        result = f(df)
+        assert len(result) == 4
+
+    def test_default_allows_duplicates_polars(self) -> None:
+        @df_in(columns={"user_id": {"dtype": pl.Int64}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"user_id": [1, 2, 2, 3]})
+        result = f(df)
+        assert len(result) == 4
+
+    def test_unique_false_allows_duplicates_pandas(self) -> None:
+        @df_in(columns={"user_id": {"unique": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"user_id": [1, 2, 2, 3]})
+        result = f(df)
+        assert len(result) == 4
+
+    def test_unique_false_allows_duplicates_polars(self) -> None:
+        @df_in(columns={"user_id": {"unique": False}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"user_id": [1, 2, 2, 3]})
+        result = f(df)
+        assert len(result) == 4

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -79,3 +79,45 @@ class TestUniqueBasic:
         df = pl.DataFrame({"user_id": [1, 2, 2, 3]})
         result = f(df)
         assert len(result) == 4
+
+
+class TestUniqueWithDtype:
+    def test_unique_with_dtype_validates_both_pandas(self) -> None:
+        @df_in(columns={"user_id": {"dtype": "int64", "unique": True}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # Wrong dtype
+        df_wrong_dtype = pd.DataFrame({"user_id": ["a", "b", "c"]})
+        with pytest.raises(AssertionError, match="wrong dtype"):
+            f(df_wrong_dtype)
+
+        # Duplicates
+        df_dups = pd.DataFrame({"user_id": [1, 2, 2, 3]})
+        with pytest.raises(AssertionError, match="duplicate value"):
+            f(df_dups)
+
+        # Valid
+        df_valid = pd.DataFrame({"user_id": [1, 2, 3, 4]})
+        result = f(df_valid)
+        assert len(result) == 4
+
+    def test_unique_with_dtype_validates_both_polars(self) -> None:
+        @df_in(columns={"user_id": {"dtype": pl.Int64, "unique": True}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        # Wrong dtype
+        df_wrong_dtype = pl.DataFrame({"user_id": ["a", "b", "c"]})
+        with pytest.raises(AssertionError, match="wrong dtype"):
+            f(df_wrong_dtype)
+
+        # Duplicates
+        df_dups = pl.DataFrame({"user_id": [1, 2, 2, 3]})
+        with pytest.raises(AssertionError, match="duplicate value"):
+            f(df_dups)
+
+        # Valid
+        df_valid = pl.DataFrame({"user_id": [1, 2, 3, 4]})
+        result = f(df_valid)
+        assert len(result) == 4

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -163,3 +163,35 @@ class TestUniqueWithNullable:
         df_valid = pl.DataFrame({"user_id": [1, 2, 3, 4]})
         result = f(df_valid)
         assert len(result) == 4
+
+
+class TestUniqueWithRegex:
+    def test_regex_unique_applies_to_all_matched_pandas(self) -> None:
+        @df_in(columns={"r/ID_\\d+/": {"unique": True}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # ID_1 has duplicates
+        df_dups = pd.DataFrame({"ID_1": [1, 1, 3], "ID_2": [1, 2, 3]})
+        with pytest.raises(AssertionError, match="duplicate value"):
+            f(df_dups)
+
+        # All unique
+        df_valid = pd.DataFrame({"ID_1": [1, 2, 3], "ID_2": [4, 5, 6]})
+        result = f(df_valid)
+        assert len(result) == 3
+
+    def test_regex_unique_applies_to_all_matched_polars(self) -> None:
+        @df_in(columns={"r/ID_\\d+/": {"unique": True}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        # ID_1 has duplicates
+        df_dups = pl.DataFrame({"ID_1": [1, 1, 3], "ID_2": [1, 2, 3]})
+        with pytest.raises(AssertionError, match="duplicate value"):
+            f(df_dups)
+
+        # All unique
+        df_valid = pl.DataFrame({"ID_1": [1, 2, 3], "ID_2": [4, 5, 6]})
+        result = f(df_valid)
+        assert len(result) == 3

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -229,3 +229,41 @@ class TestUniqueWithDfOut:
 
         result = f()
         assert len(result) == 4
+
+
+class TestUniqueBackwardsCompatibility:
+    def test_list_format_still_works_pandas(self) -> None:
+        @df_in(columns=["user_id", "name"])
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"user_id": [1, 1, 2], "name": ["a", "b", "c"]})
+        result = f(df)
+        assert len(result) == 3
+
+    def test_list_format_still_works_polars(self) -> None:
+        @df_in(columns=["user_id", "name"])
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"user_id": [1, 1, 2], "name": ["a", "b", "c"]})
+        result = f(df)
+        assert len(result) == 3
+
+    def test_simple_dtype_dict_still_works_pandas(self) -> None:
+        @df_in(columns={"user_id": "int64"})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"user_id": [1, 1, 2]})
+        result = f(df)
+        assert len(result) == 3
+
+    def test_simple_dtype_dict_still_works_polars(self) -> None:
+        @df_in(columns={"user_id": pl.Int64})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        df = pl.DataFrame({"user_id": [1, 1, 2]})
+        result = f(df)
+        assert len(result) == 3

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -121,3 +121,45 @@ class TestUniqueWithDtype:
         df_valid = pl.DataFrame({"user_id": [1, 2, 3, 4]})
         result = f(df_valid)
         assert len(result) == 4
+
+
+class TestUniqueWithNullable:
+    def test_unique_and_nullable_false_pandas(self) -> None:
+        @df_in(columns={"user_id": {"unique": True, "nullable": False}})
+        def f(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # Has nulls
+        df_nulls = pd.DataFrame({"user_id": [1.0, None, 3.0]})
+        with pytest.raises(AssertionError, match="null value"):
+            f(df_nulls)
+
+        # Has duplicates
+        df_dups = pd.DataFrame({"user_id": [1, 2, 2, 3]})
+        with pytest.raises(AssertionError, match="duplicate value"):
+            f(df_dups)
+
+        # Valid
+        df_valid = pd.DataFrame({"user_id": [1, 2, 3, 4]})
+        result = f(df_valid)
+        assert len(result) == 4
+
+    def test_unique_and_nullable_false_polars(self) -> None:
+        @df_in(columns={"user_id": {"unique": True, "nullable": False}})
+        def f(df: pl.DataFrame) -> pl.DataFrame:
+            return df
+
+        # Has nulls
+        df_nulls = pl.DataFrame({"user_id": [1.0, None, 3.0]})
+        with pytest.raises(AssertionError, match="null value"):
+            f(df_nulls)
+
+        # Has duplicates
+        df_dups = pl.DataFrame({"user_id": [1, 2, 2, 3]})
+        with pytest.raises(AssertionError, match="duplicate value"):
+            f(df_dups)
+
+        # Valid
+        df_valid = pl.DataFrame({"user_id": [1, 2, 3, 4]})
+        result = f(df_valid)
+        assert len(result) == 4


### PR DESCRIPTION
## Summary
- Add per-column uniqueness validation via rich spec format: `{"user_id": {"unique": True}}`
- Raises AssertionError when duplicates found, with helpful error messages showing duplicate count
- Works with dtype validation, nullable validation, regex patterns, and both df_in/df_out decorators
- Default is unique=False to preserve backwards compatibility

## Changes
- Add `count_duplicate_values()` utility function in `dataframe_types.py`
- Add `_find_uniqueness_violations()` helper and integrate into `validate_dataframe()` in `validation.py`
- 22 new tests covering all scenarios
- Documentation updates in `docs/usage.md`, `README.md`, `CHANGELOG.md`
- Version bump to 1.2.0

## Example Usage
```python
@df_in(columns={"user_id": {"unique": True}})
def process_users(df):
    ...

@df_in(columns={"id": {"dtype": "int64", "unique": True, "nullable": False}})
def process_data(df):
    ...
```