### PR TITLE
Add optional columns support (required=False)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.3.0
+
+### New Features
+
+- **Optional columns** - Mark columns as optional with `required=False`
+  - Use rich column spec format: `{"column": {"required": False}}`
+  - Optional columns are not required to exist in the DataFrame
+  - If present, all other validations (dtype, nullable, unique) still apply
+  - Works with regex patterns: `{"r/extra_\\d+/": {"required": False}}`
+  - Default behavior unchanged (required=True, columns must exist)
+
 ## 1.2.0
 
 ### New Features

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -28,6 +28,7 @@ class ColumnConstraints(TypedDict, total=False):
     dtype: Any
     nullable: bool
     unique: bool
+    required: bool
 
 
 ColumnsList = Sequence[Union[str, RegexColumnDef]]
@@ -150,15 +151,19 @@ def validate_dataframe(
             column_spec = (
                 compile_regex_pattern(column) if isinstance(column, str) and is_regex_string(column) else column
             )
-            all_missing_columns.extend(_find_missing_columns(column_spec, df_columns))
             all_matched_by_regex.update(find_regex_matches(column_spec, df_columns))
 
             # Handle both simple dtype specs ("float64") and rich specs ({"dtype": ..., "nullable": ...})
             if isinstance(spec_value, dict):
-                # Rich column spec: {"dtype": ..., "nullable": ..., "unique": ..., etc.}
+                # Rich column spec: {"dtype": ..., "nullable": ..., "unique": ..., "required": ..., etc.}
+                required = spec_value.get("required", True)  # Default to True (column must exist)
                 expected_dtype = spec_value.get("dtype")
                 nullable = spec_value.get("nullable", True)  # Default to True (allow nulls)
                 unique = spec_value.get("unique", False)  # Default to False (allow duplicates)
+
+                # Only check for missing columns if required=True
+                if required:
+                    all_missing_columns.extend(_find_missing_columns(column_spec, df_columns))
 
                 if expected_dtype is not None:
                     all_dtype_mismatches.extend(_find_dtype_mismatches(column_spec, df, expected_dtype, df_columns))
@@ -171,7 +176,8 @@ def validate_dataframe(
                         _find_column_violations(column_spec, df, df_columns, count_duplicate_values)
                     )
             else:
-                # Simple dtype spec: just the dtype string
+                # Simple dtype spec: just the dtype string (always required)
+                all_missing_columns.extend(_find_missing_columns(column_spec, df_columns))
                 all_dtype_mismatches.extend(_find_dtype_mismatches(column_spec, df, spec_value, df_columns))
     else:
         processed_columns = compile_regex_patterns(columns)

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -153,18 +153,14 @@ def validate_dataframe(
             )
             all_matched_by_regex.update(find_regex_matches(column_spec, df_columns))
 
-            # Handle both simple dtype specs ("float64") and rich specs ({"dtype": ..., "nullable": ...})
             if isinstance(spec_value, dict):
-                # Rich column spec: {"dtype": ..., "nullable": ..., "unique": ..., "required": ..., etc.}
-                required = spec_value.get("required", True)  # Default to True (column must exist)
+                required = spec_value.get("required", True)
                 expected_dtype = spec_value.get("dtype")
-                nullable = spec_value.get("nullable", True)  # Default to True (allow nulls)
-                unique = spec_value.get("unique", False)  # Default to False (allow duplicates)
+                nullable = spec_value.get("nullable", True)
+                unique = spec_value.get("unique", False)
 
-                # Only check for missing columns if required=True
                 if required:
                     all_missing_columns.extend(_find_missing_columns(column_spec, df_columns))
-
                 if expected_dtype is not None:
                     all_dtype_mismatches.extend(_find_dtype_mismatches(column_spec, df, expected_dtype, df_columns))
                 if not nullable:
@@ -176,7 +172,6 @@ def validate_dataframe(
                         _find_column_violations(column_spec, df, df_columns, count_duplicate_values)
                     )
             else:
-                # Simple dtype spec: just the dtype string (always required)
                 all_missing_columns.extend(_find_missing_columns(column_spec, df_columns))
                 all_dtype_mismatches.extend(_find_dtype_mismatches(column_spec, df, spec_value, df_columns))
     else:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -221,6 +221,52 @@ If a column contains duplicate values when `unique=True`, an error is raised:
 AssertionError: Column 'user_id' in function 'process_users' parameter 'df' contains 5 duplicate values but unique=True
 ```
 
+## Optional Columns
+
+By default, all specified columns are required. You can mark columns as optional using `required=False`:
+
+```python
+@df_in(columns={
+    "user_id": {"dtype": "int64"},
+    "nickname": {"dtype": "object", "required": False}
+})
+def process_users(df):
+    # user_id is required, nickname is optional
+    ...
+```
+
+### Behavior
+
+- If an optional column is missing, no error is raised
+- If an optional column is present, all other validations (dtype, nullable, unique) still apply
+
+```python
+@df_in(columns={
+    "discount": {"dtype": "float64", "nullable": False, "required": False}
+})
+def process_orders(df):
+    # discount is optional, but if present it must be float64 with no nulls
+    ...
+```
+
+### With Regex Patterns
+
+Optional columns work with regex patterns:
+
+```python
+@df_in(columns={
+    "id": {"dtype": "int64"},
+    "r/extra_\\d+/": {"dtype": "object", "required": False}
+})
+def process_data(df):
+    # Must have 'id', may optionally have extra_1, extra_2, etc.
+    ...
+```
+
+### Default Behavior
+
+By default, `required=True`, meaning all columns must exist. This preserves backwards compatibility - existing code continues to work unchanged.
+
 ## Strict Mode
 
 You can enable strict-mode for both `@df_in` and `@df_out`. This will raise an error if the DataFrame contains columns not defined in the annotation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "1.2.0"
+version = "1.3.0"
 description = "Function decorators for Pandas and Polars DataFrame validation - columns, data types, and row-level validation with Pydantic"
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -17,3 +17,17 @@ def test_optional_column_missing_ok() -> None:
     result = process(df)
 
     assert list(result.columns) == ["A"]
+
+
+def test_optional_column_present_validated() -> None:
+    """Optional column that is present should be validated normally."""
+
+    @df_in(columns={"A": "int64", "B": {"dtype": "float64", "required": False}})
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    # DataFrame has both columns, dtype is correct
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [1.0, 2.0, 3.0]})
+    result = process(df)
+
+    assert list(result.columns) == ["A", "B"]

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -1,0 +1,19 @@
+"""Tests for optional columns (required=False) feature."""
+
+import pandas as pd
+
+from daffy import df_in
+
+
+def test_optional_column_missing_ok() -> None:
+    """Optional column that is missing should not raise an error."""
+
+    @df_in(columns={"A": "int64", "B": {"dtype": "float64", "required": False}})
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    # DataFrame only has column A, missing optional column B
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    result = process(df)
+
+    assert list(result.columns) == ["A"]

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -206,8 +206,8 @@ class TestBackwardsCompatibility:
         with pytest.raises(AssertionError, match="Missing columns"):
             process(df)
 
-    def test_simple_dtype_spec_unchanged(self, df_lib: Any) -> None:
-        """Simple dtype specs (string values) still work as before."""
+    def test_rich_spec_columns_present(self, df_lib: Any) -> None:
+        """Rich specs with only required key work correctly."""
 
         @df_in(columns={"A": {"required": True}, "B": {"required": True}})
         def process(df: Any) -> Any:
@@ -217,8 +217,8 @@ class TestBackwardsCompatibility:
         result = process(df)
         assert list(result.columns) == ["A", "B"]
 
-    def test_simple_dtype_spec_missing_error(self, df_lib: Any) -> None:
-        """Simple dtype specs still require columns."""
+    def test_rich_spec_missing_required_column(self, df_lib: Any) -> None:
+        """Rich specs with required=True raise error on missing columns."""
 
         @df_in(columns={"A": {"required": True}, "B": {"required": True}})
         def process(df: Any) -> Any:

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -91,3 +91,23 @@ def test_required_default_true() -> None:
 
     with pytest.raises(AssertionError, match="Missing columns"):
         process(df)
+
+
+def test_multiple_optional_columns() -> None:
+    """Multiple optional columns can be missing."""
+
+    @df_in(
+        columns={
+            "A": "int64",
+            "B": {"dtype": "float64", "required": False},
+            "C": {"dtype": "object", "required": False},
+        }
+    )
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    # Only column A is present, both optional columns are missing
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    result = process(df)
+
+    assert list(result.columns) == ["A"]

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -76,3 +76,18 @@ def test_optional_column_unique_violation() -> None:
 
     with pytest.raises(AssertionError, match="duplicate values"):
         process(df)
+
+
+def test_required_default_true() -> None:
+    """Column without required key should be required by default."""
+    import pytest
+
+    @df_in(columns={"A": "int64", "B": {"dtype": "float64"}})
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    # DataFrame missing column B (which is required by default)
+    df = pd.DataFrame({"A": [1, 2, 3]})
+
+    with pytest.raises(AssertionError, match="Missing columns"):
+        process(df)

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -31,3 +31,18 @@ def test_optional_column_present_validated() -> None:
     result = process(df)
 
     assert list(result.columns) == ["A", "B"]
+
+
+def test_optional_column_dtype_mismatch() -> None:
+    """Optional column with wrong dtype should raise an error."""
+    import pytest
+
+    @df_in(columns={"A": "int64", "B": {"dtype": "float64", "required": False}})
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    # Column B is present but has wrong dtype (int instead of float)
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]})
+
+    with pytest.raises(AssertionError, match="wrong dtype"):
+        process(df)

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -61,3 +61,18 @@ def test_optional_column_nullable_violation() -> None:
 
     with pytest.raises(AssertionError, match="null values"):
         process(df)
+
+
+def test_optional_column_unique_violation() -> None:
+    """Optional column with duplicate values when unique=True should raise an error."""
+    import pytest
+
+    @df_in(columns={"A": "int64", "B": {"dtype": "float64", "unique": True, "required": False}})
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    # Column B is present but contains duplicate values
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [1.0, 1.0, 3.0]})
+
+    with pytest.raises(AssertionError, match="duplicate values"):
+        process(df)

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -46,3 +46,18 @@ def test_optional_column_dtype_mismatch() -> None:
 
     with pytest.raises(AssertionError, match="wrong dtype"):
         process(df)
+
+
+def test_optional_column_nullable_violation() -> None:
+    """Optional column with null values when nullable=False should raise an error."""
+    import pytest
+
+    @df_in(columns={"A": "int64", "B": {"dtype": "float64", "nullable": False, "required": False}})
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    # Column B is present but contains null values
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [1.0, None, 3.0]})
+
+    with pytest.raises(AssertionError, match="null values"):
+        process(df)

--- a/tests/test_optional_columns.py
+++ b/tests/test_optional_columns.py
@@ -111,3 +111,17 @@ def test_multiple_optional_columns() -> None:
     result = process(df)
 
     assert list(result.columns) == ["A"]
+
+
+def test_optional_with_regex() -> None:
+    """Regex pattern column with required=False should be optional."""
+
+    @df_in(columns={"A": "int64", "r/price_\\d+/": {"dtype": "float64", "required": False}})
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    # No columns matching regex pattern, but that's OK since required=False
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    result = process(df)
+
+    assert list(result.columns) == ["A"]


### PR DESCRIPTION
## Summary

- Add `required` field to column specifications allowing columns to be marked as optional
- Optional columns (`required=False`) don't raise errors when missing from DataFrame
- If an optional column IS present, all other validations (dtype, nullable, unique) still apply
- Default is `required=True` (backwards compatible)

## Usage

```python
@df_in(columns={
    "user_id": {"dtype": "int64"},                          # required (default)
    "nickname": {"dtype": "object", "required": False}      # optional
})
def process_users(df):
    ...
```

## Changes

- `daffy/validation.py` - Add `required` to ColumnConstraints TypedDict, skip missing check when `required=False`
- `tests/test_optional_columns.py` - 30 tests covering all scenarios (pandas + polars)
- `docs/usage.md` - Document optional columns feature
- `CHANGELOG.md` - Add v1.3.0 entry
- `pyproject.toml` - Bump version to 1.3.0