### PR TITLE
Remove dead code and add deadcode to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,11 +58,12 @@ jobs:
         run: |
           uv sync --group test --group dev
 
-      - name: Lint with Ruff and Pyrefly
+      - name: Lint with Ruff, Pyrefly, and Deadcode
         run: |
           uv run ruff check --output-format=github .
           uv run ruff format --diff
           uv run pyrefly check .
+          uv run deadcode daffy/
 
   # Coverage on latest Python only
   coverage:

--- a/daffy/config.py
+++ b/daffy/config.py
@@ -101,20 +101,6 @@ def get_row_validation_config() -> dict[str, Any]:
     }
 
 
-def get_row_validation_max_errors(max_errors: Optional[int] = None) -> int:
-    """Get max_errors setting for row validation."""
-    if max_errors is not None:
-        return max_errors
-    return int(get_config()[_KEY_ROW_VALIDATION_MAX_ERRORS])
-
-
-def get_row_validation_convert_nans(convert_nans: Optional[bool] = None) -> bool:
-    """Get convert_nans setting for row validation."""
-    if convert_nans is not None:
-        return convert_nans
-    return bool(get_config()[_KEY_ROW_VALIDATION_CONVERT_NANS])
-
-
 def get_checks_max_samples(max_samples: Optional[int] = None) -> int:
     """Get max_samples setting for value checks."""
     if max_samples is not None:

--- a/daffy/pydantic_types.py
+++ b/daffy/pydantic_types.py
@@ -11,24 +11,17 @@ from typing import TYPE_CHECKING
 
 # Runtime import with availability flag
 try:
-    from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
+    from pydantic import BaseModel, ValidationError
 
     HAS_PYDANTIC = True
 except ImportError:  # pragma: no cover
     BaseModel = None  # type: ignore[assignment, misc]
     ValidationError = None  # type: ignore[assignment, misc]
-    ConfigDict = None  # type: ignore[assignment, misc]
-    TypeAdapter = None  # type: ignore[assignment, misc]
     HAS_PYDANTIC = False
 
 # Compile-time types for type checkers
 if TYPE_CHECKING:
-    from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError  # noqa: F401
-
-
-def get_pydantic_available() -> bool:
-    """Check if Pydantic is available."""
-    return HAS_PYDANTIC
+    from pydantic import BaseModel, ValidationError  # noqa: F401
 
 
 def require_pydantic() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
 dev = [
     "ruff==0.14.9",
     "pyrefly==0.46.0",
+    "deadcode==2.4.1; python_version >= '3.10'",
     "coverage[toml]==7.13.0; python_version >= '3.10'",
     "pytest-cov==7.0.0",
     "pre-commit==4.5.0; python_version >= '3.10'",
@@ -119,3 +120,7 @@ ignore = [
 python-version = "3.10"
 untyped-def-behavior = "check-and-infer-return-any"
 permissive-ignores = true
+
+[tool.deadcode]
+exclude = [".venv", "tests", "scripts"]
+ignore-names = ["clear_config_cache"]

--- a/tests/test_pydantic_types.py
+++ b/tests/test_pydantic_types.py
@@ -3,17 +3,13 @@
 from daffy.pydantic_types import (
     HAS_PYDANTIC,
     BaseModel,
-    ConfigDict,
-    TypeAdapter,
     ValidationError,
-    get_pydantic_available,
     require_pydantic,
 )
 
 
 def test_pydantic_availability() -> None:
     assert HAS_PYDANTIC is True
-    assert get_pydantic_available() is True
 
 
 def test_require_pydantic() -> None:
@@ -23,5 +19,3 @@ def test_require_pydantic() -> None:
 def test_pydantic_imports_available() -> None:
     assert BaseModel is not None
     assert ValidationError is not None
-    assert ConfigDict is not None
-    assert TypeAdapter is not None

--- a/tests/test_row_validation_config.py
+++ b/tests/test_row_validation_config.py
@@ -33,27 +33,3 @@ row_validation_convert_nans = false
     assert cfg["convert_nans"] is False
 
     clear_config_cache()
-
-
-def test_explicit_overrides_config() -> None:
-    from daffy.config import (
-        get_row_validation_convert_nans,
-        get_row_validation_max_errors,
-    )
-
-    assert get_row_validation_max_errors(20) == 20
-    assert get_row_validation_convert_nans(False) is False
-
-
-def test_row_validation_max_errors_uses_default() -> None:
-    from daffy.config import get_row_validation_max_errors
-
-    result = get_row_validation_max_errors(None)
-    assert result == 5
-
-
-def test_row_validation_convert_nans_uses_default() -> None:
-    from daffy.config import get_row_validation_convert_nans
-
-    result = get_row_validation_convert_nans(None)
-    assert result is True


### PR DESCRIPTION
## Summary

- Remove unused functions identified by deadcode tool
- Add deadcode to CI for ongoing dead code detection

## Changes

**Removed dead code:**
- `get_row_validation_max_errors` and `get_row_validation_convert_nans` from config.py (redundant - `get_row_validation_config()` is used instead)
- `ConfigDict`, `TypeAdapter` imports and `get_pydantic_available()` from pydantic_types.py (unused - `HAS_PYDANTIC` is used directly)

**Added deadcode to CI:**
- Added `deadcode==2.4.1` to dev dependencies (Python 3.10+ only)
- Added `[tool.deadcode]` config in pyproject.toml
- Added deadcode check to lint job in CI workflow