### PR TITLE
Add Modin and PyArrow support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - **Migrated to Narwhals** - Major internal refactoring to use [Narwhals](https://narwhals-dev.github.io/narwhals/) as a unified DataFrame abstraction layer
   - Narwhals is a lightweight compatibility layer used by Plotly, Altair, Bokeh, and Marimo
-  - Enables future support for cuDF, Modin, and PyArrow DataFrames
-  - All existing functionality for pandas and polars remains unchanged
+  - **Now supports Modin and PyArrow** in addition to Pandas and Polars
+  - All existing functionality for Pandas and Polars remains unchanged
   - Public API (`df_in`, `df_out`, `df_log`) is fully backwards compatible
 
 ### Changed
 
-- `df_log` with `include_dtypes=True` now shows unified Narwhals dtype representation (e.g., `[String, Int64]`) for both pandas and polars DataFrames
-  - Previously pandas showed `['object', 'int64']` while polars showed `[String, Int64]`
+- `df_log` with `include_dtypes=True` now shows unified Narwhals dtype representation (e.g., `[String, Int64]`) for both Pandas and Polars DataFrames
+  - Previously Pandas showed `['object', 'int64']` while Polars showed `[String, Int64]`
   - This provides consistent logging output across all DataFrame libraries
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ def analyze_housing(houses_df):
     return analyzed_df
 ```
 
-Like type hints for DataFrames, Daffy helps you catch structural mismatches early and keeps your data pipeline documentation synchronized with the code. Column validation is lightweight and fast. For deeper validation, Daffy also supports row-level validation using Pydantic models. Compatible with both Pandas and Polars.
+Like type hints for DataFrames, Daffy helps you catch structural mismatches early and keeps your data pipeline documentation synchronized with the code. Column validation is lightweight and fast. For deeper validation, Daffy also supports row-level validation using Pydantic models. Compatible with Pandas, Polars, Modin, and PyArrow.
 
 ## Key Features
 
@@ -36,7 +36,7 @@ Like type hints for DataFrames, Daffy helps you catch structural mismatches earl
 - Informative error messages showing which rows failed and why
 
 **General**:
-- Works with both Pandas and Polars DataFrames
+- Works with Pandas, Polars, Modin, and PyArrow DataFrames
 - Project-wide configuration via pyproject.toml
 - Integrated logging for DataFrame structure inspection
 - Enhanced type annotations for improved IDE and type checker support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ test = [
     "pandas>=1.5.1,<3.0.0",
     "polars>=1.7.0",
     "pydantic>=2.4.0",
+    "modin[ray]>=0.30.0",
+    "pyarrow>=14.0.0",
 ]
 
 # Development tools - pinned for dependabot updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
     "pandas>=1.5.1,<3.0.0",
     "polars>=1.7.0",
     "pydantic>=2.4.0",
-    "modin[ray]>=0.30.0",
+    "modin[ray]>=0.30.0; python_version >= '3.10' and python_version < '3.14'",
     "pyarrow>=14.0.0",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,18 @@
 from typing import Any, Callable, Union
 
-import modin.pandas as mpd
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
+
+# Modin requires ray which only supports Python 3.10-3.13
+try:
+    import modin.pandas as mpd
+
+    HAS_MODIN = True
+except ImportError:
+    mpd = None  # type: ignore[assignment]
+    HAS_MODIN = False
 
 DataFrameType = Union[pd.DataFrame, pl.DataFrame]
 
@@ -25,9 +33,9 @@ def make_polars_df(data: dict[str, Any]) -> pl.DataFrame:
     return pl.DataFrame(data)
 
 
-def make_modin_df(data: dict[str, Any]) -> mpd.DataFrame:
+def make_modin_df(data: dict[str, Any]) -> Any:
     """Create a modin DataFrame."""
-    return mpd.DataFrame(data)
+    return mpd.DataFrame(data)  # type: ignore[union-attr]
 
 
 def make_pyarrow_table(data: dict[str, Any]) -> pa.Table:
@@ -38,9 +46,11 @@ def make_pyarrow_table(data: dict[str, Any]) -> pa.Table:
 DF_FACTORIES = [
     pytest.param(make_pandas_df, id="pandas"),
     pytest.param(make_polars_df, id="polars"),
-    pytest.param(make_modin_df, id="modin"),
     pytest.param(make_pyarrow_table, id="pyarrow"),
 ]
+
+if HAS_MODIN:
+    DF_FACTORIES.insert(2, pytest.param(make_modin_df, id="modin"))
 
 
 @pytest.fixture(params=DF_FACTORIES)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
-from typing import Union
+from typing import Any, Callable, Union
 
+import modin.pandas as mpd
 import pandas as pd
 import polars as pl
+import pyarrow as pa
 import pytest
 
 DataFrameType = Union[pd.DataFrame, pl.DataFrame]
@@ -10,6 +12,40 @@ DataFrameType = Union[pd.DataFrame, pl.DataFrame]
 @pytest.fixture(params=[pd, pl], ids=["pandas", "polars"])
 def df_lib(request: pytest.FixtureRequest) -> type:
     """Return pd or pl module for creating DataFrames."""
+    return request.param
+
+
+def make_pandas_df(data: dict[str, Any]) -> pd.DataFrame:
+    """Create a pandas DataFrame."""
+    return pd.DataFrame(data)
+
+
+def make_polars_df(data: dict[str, Any]) -> pl.DataFrame:
+    """Create a polars DataFrame."""
+    return pl.DataFrame(data)
+
+
+def make_modin_df(data: dict[str, Any]) -> mpd.DataFrame:
+    """Create a modin DataFrame."""
+    return mpd.DataFrame(data)
+
+
+def make_pyarrow_table(data: dict[str, Any]) -> pa.Table:
+    """Create a PyArrow Table."""
+    return pa.table(data)
+
+
+DF_FACTORIES = [
+    pytest.param(make_pandas_df, id="pandas"),
+    pytest.param(make_polars_df, id="polars"),
+    pytest.param(make_modin_df, id="modin"),
+    pytest.param(make_pyarrow_table, id="pyarrow"),
+]
+
+
+@pytest.fixture(params=DF_FACTORIES)
+def make_df(request: pytest.FixtureRequest) -> Callable[[dict[str, Any]], Any]:
+    """Factory fixture for creating DataFrames across all supported libraries."""
     return request.param
 
 

--- a/tests/test_dataframe_backends.py
+++ b/tests/test_dataframe_backends.py
@@ -1,0 +1,56 @@
+"""Tests for DataFrame backend compatibility (pandas, polars, modin, pyarrow)."""
+
+from typing import Any, Callable
+
+import pytest
+
+from daffy import df_in, df_out
+
+cars = {
+    "Brand": ["Honda Civic", "Toyota Corolla", "Ford Focus", "Audi A4"],
+    "Price": [22000, 25000, 27000, 35000],
+}
+
+
+class TestBackendCompatibility:
+    """Test core daffy functionality across all supported DataFrame backends."""
+
+    def test_df_out_validates_columns(self, make_df: Callable[[dict[str, Any]], Any]) -> None:
+        @df_out(columns=["Brand", "Price"])
+        def get_data() -> Any:
+            return make_df(cars)
+
+        result = get_data()
+        assert result is not None
+
+    def test_df_in_validates_columns(self, make_df: Callable[[dict[str, Any]], Any]) -> None:
+        @df_in(columns=["Brand", "Price"])
+        def process(df: Any) -> Any:
+            return df
+
+        result = process(make_df(cars))
+        assert result is not None
+
+    def test_strict_mode_rejects_extra_columns(self, make_df: Callable[[dict[str, Any]], Any]) -> None:
+        @df_in(columns=["Brand"], strict=True)
+        def process(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match="unexpected column"):
+            process(make_df(cars))
+
+    def test_missing_column_raises_error(self, make_df: Callable[[dict[str, Any]], Any]) -> None:
+        @df_in(columns=["Brand", "Price", "NonExistent"])
+        def process(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match="NonExistent"):
+            process(make_df(cars))
+
+    def test_regex_column_pattern(self, make_df: Callable[[dict[str, Any]], Any]) -> None:
+        @df_in(columns=["r/.*/"])
+        def process(df: Any) -> Any:
+            return df
+
+        result = process(make_df(cars))
+        assert result is not None


### PR DESCRIPTION
## Summary

- Add test coverage for Modin and PyArrow DataFrame backends
- Update docs and release notes to reflect 2.0.0 supports 4 DataFrame libraries

## Changes

- Added `modin[ray]` and `pyarrow` to test dependencies
- Created `tests/test_dataframe_backends.py` with parametrized tests across all 4 backends
- Updated README and CHANGELOG to mention Modin and PyArrow support