### PR TITLE
Update docs to mention all supported DataFrame backends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Daffy is a DataFrame column validator library that provides runtime validation decorators (`@df_in`, `@df_out`, `@df_log`) for Pandas and Polars DataFrames. It validates column names (including regex patterns), data types, and enforces strictness rules through simple function decorators.
+Daffy is a DataFrame column validator library that provides runtime validation decorators (`@df_in`, `@df_out`, `@df_log`) for Pandas, Polars, Modin, and PyArrow DataFrames. It validates column names (including regex patterns), data types, and enforces strictness rules through simple function decorators.
 
 ## Workflow
 
@@ -286,7 +286,7 @@ Decorator parameters override config file settings:
 
 - **Python 3.9+ compatibility**: Code must work on Python 3.9-3.14
 - **Type hints required**: All functions should have proper type annotations (Ruff ANN rules)
-- **No hard dependencies**: pandas and polars are optional; only tomli is required
+- **No hard dependencies**: DataFrame libraries (Pandas, Polars, Modin, PyArrow) are optional; only tomli and narwhals are required
 - **Coverage threshold**: 95% minimum (excluding dataframe_types.py)
 - **Import organization**: Use TYPE_CHECKING for static vs runtime type imports
 

--- a/TESTING_OPTIONAL_DEPS.md
+++ b/TESTING_OPTIONAL_DEPS.md
@@ -1,6 +1,6 @@
 # Testing Optional Dependencies
 
-This document describes how to test daffy's optional dependency support for pandas and polars.
+This document describes how to test daffy's optional dependency support for DataFrame libraries (Pandas, Polars, Modin, PyArrow).
 
 ## Background
 
@@ -73,10 +73,10 @@ uv run --no-project --with "$WHEEL" python scripts/test_isolated_deps.py none
 #### Both Libraries
 - `HAS_PANDAS = True`, `HAS_POLARS = True`
 - Both DataFrame types work
-- Error messages mention "Pandas or Polars DataFrame"
+- Error messages mention available DataFrame types
 
 #### No Libraries
-- Import should fail with: `ImportError: No DataFrame library found. Please install Pandas or Polars`
+- Import should fail with: `ImportError: No DataFrame library found. Install a supported library: pip install pandas`
 
 ## Implementation Details
 

--- a/daffy/dataframe_types.py
+++ b/daffy/dataframe_types.py
@@ -1,4 +1,4 @@
-"""DataFrame type handling for DAFFY - supports Pandas and Polars."""
+"""DataFrame type handling for DAFFY - supports Pandas, Polars, Modin, and PyArrow."""
 
 from __future__ import annotations
 
@@ -38,7 +38,7 @@ else:
 
     if not _available_types:
         raise ImportError(
-            "No DataFrame library found. Please install Pandas or Polars: pip install pandas  OR  pip install polars"
+            "No DataFrame library found. Install a supported library: pip install pandas"
         )
 
     DataFrameType = Union[tuple(_available_types)]

--- a/daffy/dataframe_types.py
+++ b/daffy/dataframe_types.py
@@ -37,9 +37,7 @@ else:
         _available_types.append(PolarsDataFrame)
 
     if not _available_types:
-        raise ImportError(
-            "No DataFrame library found. Install a supported library: pip install pandas"
-        )
+        raise ImportError("No DataFrame library found. Install a supported library: pip install pandas")
 
     DataFrameType = Union[tuple(_available_types)]
 

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -59,7 +59,7 @@ def df_out(
     strict: bool | None = None,
     row_validator: "type[BaseModel] | None" = None,
 ) -> Callable[[Callable[..., DF]], Callable[..., DF]]:
-    """Decorate a function that returns a Pandas or Polars DataFrame.
+    """Decorate a function that returns a DataFrame (Pandas, Polars, Modin, or PyArrow).
 
     Document the return value of a function. The return value will be validated in runtime.
 
@@ -102,7 +102,7 @@ def df_in(
     strict: bool | None = None,
     row_validator: "type[BaseModel] | None" = None,
 ) -> Callable[[Callable[..., R]], Callable[..., R]]:
-    """Decorate a function parameter that is a Pandas or Polars DataFrame.
+    """Decorate a function parameter that is a DataFrame (Pandas, Polars, Modin, or PyArrow).
 
     Document the contents of an input parameter. The parameter will be validated in runtime.
 

--- a/daffy/row_validation.py
+++ b/daffy/row_validation.py
@@ -1,8 +1,7 @@
 """Row-level DataFrame validation using Pydantic models.
 
 This module provides efficient row-by-row validation of DataFrames using Pydantic
-models. It supports both pandas and polars DataFrames with optimized conversion
-and validation strategies.
+models. It supports Pandas, Polars, Modin, and PyArrow DataFrames.
 """
 
 from __future__ import annotations
@@ -37,7 +36,7 @@ def validate_dataframe_rows(
     Validate DataFrame rows against a Pydantic model.
 
     Args:
-        df: DataFrame to validate (pandas or polars)
+        df: DataFrame to validate (Pandas, Polars, Modin, or PyArrow)
         row_validator: Pydantic BaseModel class for validation
         max_errors: Maximum number of errors to collect before stopping
         early_termination: Stop scanning after max_errors reached (faster for large datasets)

--- a/daffy/utils.py
+++ b/daffy/utils.py
@@ -14,7 +14,7 @@ from daffy.narwhals_compat import is_supported_dataframe
 
 
 def assert_is_dataframe(obj: Any, context: str) -> None:
-    """Verify that an object is a pandas or polars DataFrame.
+    """Verify that an object is a supported DataFrame (Pandas, Polars, Modin, or PyArrow).
 
     Args:
         obj: Object to validate

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -134,7 +134,7 @@ def validate_dataframe(
     """Validate DataFrame columns and optionally data types.
 
     Args:
-        df: DataFrame to validate (pandas or polars)
+        df: DataFrame to validate (Pandas, Polars, Modin, or PyArrow)
         columns: Column specification - list of names/patterns or dict mapping names to dtypes
         strict: If True, disallow extra columns not in the specification
         param_name: Parameter name for error context

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,7 +43,7 @@ uv run pyrefly check .
 
 ## Testing
 
-The project uses pytest for testing. Tests are parametrized to run against both pandas and polars DataFrames.
+The project uses pytest for testing. Tests are parametrized to run against multiple DataFrame backends (Pandas, Polars, Modin, and PyArrow).
 
 ### Test Files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "daffy"
 version = "2.0.0"
-description = "Function decorators for Pandas and Polars DataFrame validation - columns, data types, and row-level validation with Pydantic"
+description = "Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow."
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },
 ]

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -29,7 +29,8 @@ def test_wrong_input_type_named() -> None:
     with pytest.raises(AssertionError) as excinfo:
         test_fn(my_input="foobar")
 
-    assert "Wrong parameter type. Expected Pandas or Polars DataFrame, got str instead." in str(excinfo.value)
+    assert "Wrong parameter type" in str(excinfo.value)
+    assert "got str instead" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(("df"), [pd.DataFrame(cars), pl.DataFrame(cars)])
@@ -58,7 +59,8 @@ def test_dfin_with_no_inputs() -> None:
     with pytest.raises(AssertionError) as excinfo:
         test_fn()
 
-    assert "Wrong parameter type. Expected Pandas or Polars DataFrame, got NoneType instead." in str(excinfo.value)
+    assert "Wrong parameter type" in str(excinfo.value)
+    assert "got NoneType instead" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(("df"), [pd.DataFrame(cars), pl.DataFrame(cars)])

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -47,14 +47,10 @@ class TestOptionalDependenciesDetection:
         error_msg = str(excinfo.value)
 
         # Check that error message mentions available libraries
-        if HAS_PANDAS and HAS_POLARS:
-            assert "Pandas or Polars" in error_msg
-        elif HAS_PANDAS:
+        if HAS_PANDAS:
             assert "Pandas" in error_msg
-            assert "Polars" not in error_msg
-        elif HAS_POLARS:
+        if HAS_POLARS:
             assert "Polars" in error_msg
-            assert "Pandas" not in error_msg
 
     def test_dataframe_validation_works_with_available_libraries(self) -> None:
         """Test that DataFrame validation works with whatever libraries are available."""


### PR DESCRIPTION
Update documentation, docstrings, and error messages to reflect that Daffy now supports Pandas, Polars, Modin, and PyArrow DataFrames.

## Changes

- Updated pyproject.toml description
- Updated module docstrings in decorators.py, validation.py, row_validation.py, utils.py, dataframe_types.py
- Updated CLAUDE.md, TESTING_OPTIONAL_DEPS.md, docs/development.md
- Simplified error message assertions in tests (no longer hardcode library names)