### PR TITLE
Modernize documentation for all DataFrame backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.1
+
+### Documentation
+
+- Simplified installation instructions - Daffy detects and works with whatever DataFrame library you have installed
+- Updated PyPI keywords to include modin, pyarrow, and narwhals
+- Added note that examples work with all supported backends (Pandas, Polars, Modin, PyArrow)
+
 ## 2.0.0
 
 ### Major Refactoring
@@ -30,7 +38,7 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
-- **Vectorized value checks** - Fast validation of column values using native pandas/polars operations
+- **Vectorized value checks** - Fast validation of column values using vectorized DataFrame operations
   - Comparison checks: `gt`, `ge`, `lt`, `le` (greater than, greater or equal, less than, less or equal)
   - Range check: `between` for inclusive range validation
   - Equality checks: `eq`, `ne` for exact value matching

--- a/README.md
+++ b/README.md
@@ -68,18 +68,11 @@ Different tools serve different needs. Here's how Daffy compares:
 
 ## Installation
 
-Install with your favorite Python dependency manager:
-
 ```sh
 pip install daffy
 ```
 
-Daffy works with **pandas**, **polars**, or both - install whichever you need:
-
-```sh
-pip install pandas   # for pandas support
-pip install polars   # for polars support
-```
+Daffy works with whatever DataFrame library you already have installed: Pandas, Polars, Modin, or PyArrow. No additional dependencies required.
 
 **Python version support:** 3.9 - 3.14
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,6 +1,6 @@
 # Daffy Recipes & Patterns
 
-Practical examples showing Daffy in common scenarios.
+Practical examples showing Daffy in common scenarios. Examples use Pandas, but Polars, Modin, and PyArrow work identically.
 
 ## ETL Pipeline Validation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -269,7 +269,7 @@ By default, `required=True`, meaning all columns must exist. This preserves back
 
 ## Value Checks
 
-You can validate column values using vectorized checks. This is faster than row-by-row validation because it uses native pandas/polars operations:
+You can validate column values using vectorized checks. This is faster than row-by-row validation because it uses vectorized DataFrame operations:
 
 ```python
 @df_in(columns={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "2.0.0"
+version = "2.0.1"
 description = "Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow."
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },
@@ -8,7 +8,7 @@ authors = [
 license = "MIT"
 requires-python = ">=3.9"
 readme = "README.md"
-keywords = ["pandas", "polars", "pydantic", "dataframe", "decorator", "validation", "schema", "data-validation", "typing", "data-quality", "column-validation", "dataframe-schema", "row-validation", "runtime-validation", "data-pipeline"]
+keywords = ["pandas", "polars", "modin", "pyarrow", "narwhals", "pydantic", "dataframe", "decorator", "validation", "schema", "data-validation", "typing", "data-quality", "column-validation", "dataframe-schema", "row-validation", "runtime-validation", "data-pipeline"]
 classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/scripts/README_BENCHMARKS.md
+++ b/scripts/README_BENCHMARKS.md
@@ -28,10 +28,12 @@ python scripts/benchmark_row_validation.py --size 10000
 ## What Gets Benchmarked
 
 ### Libraries Compared
-- **Daffy (pandas)**: Our batch validation with pandas DataFrames
-- **Daffy (polars)**: Our batch validation with polars DataFrames
+- **Daffy (pandas)**: Batch validation with Pandas DataFrames
+- **Daffy (polars)**: Batch validation with Polars DataFrames
 - **Pandantic**: Competing library for DataFrame validation with Pydantic
 - **Pydantic (baseline)**: Raw row-by-row validation (only for ≤10k rows)
+
+*Note: Daffy also supports Modin and PyArrow with the same validation features, but they are not benchmarked here.*
 
 ### Scenarios
 - **Simple**: 3 fields (name, age, price) with basic constraints


### PR DESCRIPTION
## Summary

- Simplify installation section - just `pip install daffy`
- Emphasize that Daffy detects whatever DataFrame library you have installed
- Update PyPI keywords: add modin, pyarrow, narwhals
- Add backend compatibility note to recipes
- Use "vectorized DataFrame operations" instead of "pandas/polars"

Bump to 2.0.1