### PR TITLE
Fix docs index page rendering on RTD

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,10 +60,24 @@ Works with whatever DataFrame library you already have installed. Python 3.9–3
 
 Most DataFrame validation tools are schema-first (define schemas separately) or pipeline-wide (run suites over datasets). **Daffy is decorator-first:** validate inputs and outputs where transformations happen.
 
-- **Non-intrusive** — Just add decorators — no refactoring, no custom DataFrame types, no schema files
-- **Easy to adopt** — Add in 30 seconds, remove just as fast if needed
-- **In-process** — No external stores, orchestrators, or infrastructure
-- **Pay for what you use** — Column validation is essentially free; opt into row validation when needed
+<table>
+<tr>
+<td>✓</td>
+<td><strong>Non-intrusive</strong> — Just add decorators — no refactoring, no custom DataFrame types, no schema files</td>
+</tr>
+<tr>
+<td>✓</td>
+<td><strong>Easy to adopt</strong> — Add in 30 seconds, remove just as fast if needed</td>
+</tr>
+<tr>
+<td>✓</td>
+<td><strong>In-process</strong> — No external stores, orchestrators, or infrastructure</td>
+</tr>
+<tr>
+<td>✓</td>
+<td><strong>Pay for what you use</strong> — Column validation is essentially free; opt into row validation when needed</td>
+</tr>
+</table>
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,25 @@ Daffy catches missing columns, wrong data types, and invalid values at runtime �
 
 Also supports Modin and PyArrow DataFrames.
 
-- **Lightweight** — Column & dtype validation with minimal overhead
-- **Value Constraints** — Nullability, uniqueness, range checks
-- **Row Validation** — Deep validation with Pydantic models
-- **Multi-Backend** — Works with pandas, Polars, Modin, PyArrow
+<div class="grid cards" markdown>
+
+- :material-lightning-bolt: **Lightweight**
+
+    Column & dtype validation with minimal overhead
+
+- :material-check-all: **Value Constraints**
+
+    Nullability, uniqueness, range checks
+
+- :material-shield-check: **Row Validation**
+
+    Deep validation with Pydantic models
+
+- :material-swap-horizontal: **Multi-Backend**
+
+    Works with pandas, Polars, Modin, PyArrow
+
+</div>
 
 ## Quick Example
 
@@ -27,11 +42,17 @@ If a column is missing, has wrong dtype, or violates a constraint — **Daffy fa
 
 ## Installation
 
-```bash
-pip install daffy
-# or
-conda install -c conda-forge daffy
-```
+=== "pip"
+
+    ```bash
+    pip install daffy
+    ```
+
+=== "conda"
+
+    ```bash
+    conda install -c conda-forge daffy
+    ```
 
 Works with whatever DataFrame library you already have installed. Python 3.9–3.14.
 
@@ -46,7 +67,22 @@ Most DataFrame validation tools are schema-first (define schemas separately) or 
 
 ## Next Steps
 
-- **[Getting Started](getting-started.md)** — Quick introduction to Daffy's core features
-- **[Usage Guide](usage.md)** — Comprehensive reference for all features
-- **[Recipes & Patterns](recipes.md)** — Real-world examples and best practices
-- **[API Reference](api.md)** — Decorator signatures and parameters
+<div class="grid cards" markdown>
+
+- :material-rocket-launch: **[Getting Started](getting-started.md)**
+
+    Quick introduction to Daffy's core features
+
+- :material-book-open-variant: **[Usage Guide](usage.md)**
+
+    Comprehensive reference for all features
+
+- :material-chef-hat: **[Recipes & Patterns](recipes.md)**
+
+    Real-world examples and best practices
+
+- :material-api: **[API Reference](api.md)**
+
+    Decorator signatures and parameters
+
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,25 +6,10 @@ Daffy catches missing columns, wrong data types, and invalid values at runtime �
 
 Also supports Modin and PyArrow DataFrames.
 
-<div class="grid cards" markdown>
-
-- :material-lightning-bolt: **Lightweight**
-
-    Column & dtype validation with minimal overhead
-
-- :material-check-all: **Value Constraints**
-
-    Nullability, uniqueness, range checks
-
-- :material-shield-check: **Row Validation**
-
-    Deep validation with Pydantic models
-
-- :material-swap-horizontal: **Multi-Backend**
-
-    Works with pandas, Polars, Modin, PyArrow
-
-</div>
+- **Lightweight** — Column & dtype validation with minimal overhead
+- **Value Constraints** — Nullability, uniqueness, range checks
+- **Row Validation** — Deep validation with Pydantic models
+- **Multi-Backend** — Works with pandas, Polars, Modin, PyArrow
 
 ## Quick Example
 
@@ -42,17 +27,11 @@ If a column is missing, has wrong dtype, or violates a constraint — **Daffy fa
 
 ## Installation
 
-=== "pip"
-
-    ```bash
-    pip install daffy
-    ```
-
-=== "conda"
-
-    ```bash
-    conda install -c conda-forge daffy
-    ```
+```bash
+pip install daffy
+# or
+conda install -c conda-forge daffy
+```
 
 Works with whatever DataFrame library you already have installed. Python 3.9–3.14.
 
@@ -60,31 +39,14 @@ Works with whatever DataFrame library you already have installed. Python 3.9–3
 
 Most DataFrame validation tools are schema-first (define schemas separately) or pipeline-wide (run suites over datasets). **Daffy is decorator-first:** validate inputs and outputs where transformations happen.
 
-| | |
-|---|---|
-| **Non-intrusive** | Just add decorators — no refactoring, no custom DataFrame types, no schema files |
-| **Easy to adopt** | Add in 30 seconds, remove just as fast if needed |
-| **In-process** | No external stores, orchestrators, or infrastructure |
-| **Pay for what you use** | Column validation is essentially free; opt into row validation when needed |
+- **Non-intrusive** — Just add decorators — no refactoring, no custom DataFrame types, no schema files
+- **Easy to adopt** — Add in 30 seconds, remove just as fast if needed
+- **In-process** — No external stores, orchestrators, or infrastructure
+- **Pay for what you use** — Column validation is essentially free; opt into row validation when needed
 
 ## Next Steps
 
-<div class="grid cards" markdown>
-
-- :material-rocket-launch: **[Getting Started](getting-started.md)**
-
-    Quick introduction to Daffy's core features
-
-- :material-book-open-variant: **[Usage Guide](usage.md)**
-
-    Comprehensive reference for all features
-
-- :material-chef-hat: **[Recipes & Patterns](recipes.md)**
-
-    Real-world examples and best practices
-
-- :material-api: **[API Reference](api.md)**
-
-    Decorator signatures and parameters
-
-</div>
+- **[Getting Started](getting-started.md)** — Quick introduction to Daffy's core features
+- **[Usage Guide](usage.md)** — Comprehensive reference for all features
+- **[Recipes & Patterns](recipes.md)** — Real-world examples and best practices
+- **[API Reference](api.md)** — Decorator signatures and parameters

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,8 @@ plugins:
   - include-markdown
 
 markdown_extensions:
+  - attr_list
+  - md_in_html
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,9 @@ plugins:
 markdown_extensions:
   - attr_list
   - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
## Summary

- Add missing `attr_list` and `md_in_html` markdown extensions for Material theme grid cards
- Restore Material theme features (grid cards, tabs, icons) in docs index
- Replace empty-header table with list in "Why Daffy?" section