### PR TITLE
Add custom check functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.0
+
+### New Features
+
+- Custom check functions: use lambdas for validation logic not covered by built-in checks
+  - The function receives a Narwhals Series and returns a boolean Series (True = valid)
+  - Example: `{"price": {"checks": {"no_outliers": lambda s: s < s.mean() * 10}}}`
+  - The dictionary key becomes the check name in error messages
+
 ## 2.1.0
 
 ### New Features

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -269,6 +269,43 @@ def process_data(df):
     ...
 ```
 
+### Custom Check Functions
+
+For validation logic not covered by built-in checks, you can use custom functions. The function receives a [Narwhals Series](https://narwhals-dev.github.io/narwhals/) and should return a boolean Series where `True` means valid:
+
+```python
+@df_in(columns={
+    "price": {"checks": {
+        "gt": 0,  # built-in check
+        "no_outliers": lambda s: s < s.mean() * 10  # custom check
+    }}
+})
+def process_data(df):
+    ...
+```
+
+The dictionary key becomes the check name in error messages:
+
+```
+AssertionError: Column 'price' failed check 'no_outliers': 3 values failed. Examples: [50000, 99999]
+```
+
+Custom checks can use any Narwhals Series operations:
+
+```python
+@df_in(columns={
+    "email": {"checks": {
+        "has_at": lambda s: s.str.contains("@"),
+        "reasonable_length": lambda s: (s.str.len_chars() >= 5) & (s.str.len_chars() <= 254)
+    }},
+    "score": {"checks": {
+        "within_3_std": lambda s: (s - s.mean()).abs() <= s.std() * 3
+    }}
+})
+def process_data(df):
+    ...
+```
+
 ### Error Messages
 
 When checks fail, you get informative error messages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "2.1.0"
+version = "2.2.0"
 description = "Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow."
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },

--- a/tests/test_custom_checks.py
+++ b/tests/test_custom_checks.py
@@ -1,0 +1,135 @@
+"""Tests for custom check functions (callable checks)."""
+
+import pandas as pd
+import pytest
+
+from daffy import df_in
+from daffy.checks import apply_check
+
+
+class TestCustomCheckFunctions:
+    def test_custom_check_passes(self) -> None:
+        series = pd.Series([1, 2, 3, 4, 5])
+        fail_count, samples = apply_check(series, "positive", lambda s: s > 0)
+        assert fail_count == 0
+        assert samples == []
+
+    def test_custom_check_fails(self) -> None:
+        series = pd.Series([1, -2, 3, -4, 5])
+        fail_count, samples = apply_check(series, "positive", lambda s: s > 0)
+        assert fail_count == 2
+        assert -2 in samples
+        assert -4 in samples
+
+    def test_custom_check_with_mean(self) -> None:
+        series = pd.Series([1, 2, 3, 100])  # 100 is outlier (mean ~26.5)
+        fail_count, samples = apply_check(series, "no_outliers", lambda s: s < s.mean() * 3)
+        assert fail_count == 1
+        assert samples == [100]
+
+    def test_custom_check_all_fail(self) -> None:
+        series = pd.Series([-1, -2, -3])
+        fail_count, samples = apply_check(series, "positive", lambda s: s > 0)
+        assert fail_count == 3
+
+    def test_custom_check_empty_series(self) -> None:
+        series = pd.Series([], dtype=float)
+        fail_count, samples = apply_check(series, "positive", lambda s: s > 0)
+        assert fail_count == 0
+        assert samples == []
+
+    def test_custom_check_with_nulls_treated_as_failure(self) -> None:
+        series = pd.Series([1, None, 3])
+        fail_count, samples = apply_check(series, "positive", lambda s: s > 0)
+        assert fail_count == 1  # null is treated as failure
+
+    def test_custom_check_max_samples(self) -> None:
+        series = pd.Series([-1, -2, -3, -4, -5, -6, -7, -8, -9, -10])
+        fail_count, samples = apply_check(series, "positive", lambda s: s > 0, max_samples=3)
+        assert fail_count == 10
+        assert len(samples) == 3
+
+    def test_custom_check_string_validation(self) -> None:
+        series = pd.Series(["hello", "world", "hi"])
+        fail_count, samples = apply_check(series, "long_enough", lambda s: s.str.len_chars() >= 4)
+        assert fail_count == 1
+        assert samples == ["hi"]
+
+
+class TestCustomCheckWithDecorator:
+    def test_decorator_with_custom_check(self) -> None:
+        @df_in(columns={"price": {"checks": {"positive": lambda s: s > 0}}})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"price": [1, 2, 3]})
+        result = process(df)
+        assert len(result) == 3
+
+    def test_decorator_with_custom_check_fails(self) -> None:
+        @df_in(columns={"price": {"checks": {"no_negatives": lambda s: s >= 0}}})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"price": [1, -2, 3]})
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        assert "no_negatives" in str(exc_info.value)
+        assert "-2" in str(exc_info.value)
+
+    def test_decorator_mixed_builtin_and_custom_checks(self) -> None:
+        @df_in(
+            columns={
+                "price": {
+                    "checks": {
+                        "gt": 0,  # built-in
+                        "reasonable": lambda s: s < 10000,  # custom
+                    }
+                }
+            }
+        )
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # Both pass
+        df = pd.DataFrame({"price": [100, 200, 300]})
+        result = process(df)
+        assert len(result) == 3
+
+        # Built-in fails
+        df = pd.DataFrame({"price": [0, 100, 200]})
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        assert "gt" in str(exc_info.value)
+
+        # Custom fails
+        df = pd.DataFrame({"price": [100, 50000]})
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        assert "reasonable" in str(exc_info.value)
+
+    def test_decorator_custom_check_with_dtype(self) -> None:
+        @df_in(
+            columns={
+                "score": {
+                    "dtype": "int64",
+                    "checks": {"valid_range": lambda s: (s >= 0) & (s <= 100)},
+                }
+            }
+        )
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"score": [50, 75, 100]})
+        result = process(df)
+        assert len(result) == 3
+
+    def test_custom_check_error_shows_check_name(self) -> None:
+        @df_in(columns={"value": {"checks": {"my_custom_validation": lambda s: s != 999}}})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"value": [1, 999, 3]})
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        assert "my_custom_validation" in str(exc_info.value)


### PR DESCRIPTION
Allow lambdas for validation logic not covered by built-in checks.

```python
@df_in(columns={
    "price": {"checks": {
        "gt": 0,  # built-in
        "no_outliers": lambda s: s < s.mean() * 10  # custom
    }}
})
def process_data(df):
    ...
```

The function receives a Narwhals Series and should return a boolean Series (True = valid). The dictionary key becomes the check name in error messages.