### PR TITLE
Add lazy validation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
   - The function receives a Narwhals Series and returns a boolean Series (True = valid)
   - Example: `{"price": {"checks": {"no_outliers": lambda s: s < s.mean() * 10}}}`
   - The dictionary key becomes the check name in error messages
+- Lazy validation: collect all errors before raising with `lazy=True` parameter
+  - Use `@df_in(columns=..., lazy=True)` or `@df_out(columns=..., lazy=True)`
+  - Configurable via `[tool.daffy] lazy = true` in pyproject.toml
+  - Useful for debugging DataFrames with multiple issues
 
 ## 2.1.0
 

--- a/daffy/config.py
+++ b/daffy/config.py
@@ -8,11 +8,13 @@ import tomli
 
 # Configuration keys
 _KEY_STRICT = "strict"
+_KEY_LAZY = "lazy"
 _KEY_ROW_VALIDATION_MAX_ERRORS = "row_validation_max_errors"
 _KEY_CHECKS_MAX_SAMPLES = "checks_max_samples"
 
 # Default values
 _DEFAULT_STRICT = False
+_DEFAULT_LAZY = False
 _DEFAULT_MAX_ERRORS = 5
 _DEFAULT_CHECKS_MAX_SAMPLES = 5
 
@@ -26,6 +28,7 @@ def load_config() -> dict[str, Any]:
     """
     default_config = {
         _KEY_STRICT: _DEFAULT_STRICT,
+        _KEY_LAZY: _DEFAULT_LAZY,
         _KEY_ROW_VALIDATION_MAX_ERRORS: _DEFAULT_MAX_ERRORS,
         _KEY_CHECKS_MAX_SAMPLES: _DEFAULT_CHECKS_MAX_SAMPLES,
     }
@@ -45,6 +48,8 @@ def load_config() -> dict[str, Any]:
         # Update default config with values from pyproject.toml
         if _KEY_STRICT in daffy_config:
             default_config[_KEY_STRICT] = bool(daffy_config[_KEY_STRICT])
+        if _KEY_LAZY in daffy_config:
+            default_config[_KEY_LAZY] = bool(daffy_config[_KEY_LAZY])
         if _KEY_ROW_VALIDATION_MAX_ERRORS in daffy_config:
             default_config[_KEY_ROW_VALIDATION_MAX_ERRORS] = int(daffy_config[_KEY_ROW_VALIDATION_MAX_ERRORS])
         if _KEY_CHECKS_MAX_SAMPLES in daffy_config:
@@ -85,6 +90,23 @@ def get_strict(strict_param: Optional[bool] = None) -> bool:
     if strict_param is not None:
         return strict_param
     return bool(get_config()[_KEY_STRICT])
+
+
+def get_lazy(lazy_param: Optional[bool] = None) -> bool:
+    """
+    Get the lazy mode setting, with explicit parameter taking precedence over configuration.
+
+    When lazy=True, validation collects all errors before raising instead of stopping at the first.
+
+    Args:
+        lazy_param: Explicitly provided lazy parameter value, or None to use config
+
+    Returns:
+        bool: The effective lazy mode setting
+    """
+    if lazy_param is not None:
+        return lazy_param
+    return bool(get_config()[_KEY_LAZY])
 
 
 def get_row_validation_max_errors() -> int:

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -427,6 +427,32 @@ def process_employees(df):
     return df
 ```
 
+## Lazy Validation
+
+By default, validation stops at the first error type. With `lazy=True`, all errors are collected and reported together:
+
+```python
+@df_in(columns={
+    "price": {"dtype": "float64", "nullable": False},
+    "quantity": {"dtype": "int64", "checks": {"gt": 0}},
+    "category": "object"
+}, lazy=True)
+def process_order(df):
+    ...
+```
+
+When multiple validations fail, the error message includes all issues:
+
+```
+Missing columns: ['category'] in function 'process_order' parameter 'df'. Got columns: ['price', 'quantity']
+
+Column 'price' contains 2 null values but nullable=False
+
+Column 'quantity' failed check gt: 1 values failed. Examples: [-5]
+```
+
+This is useful for debugging when a DataFrame has multiple issues.
+
 ## Configuration
 
 All configuration options can be set in `pyproject.toml`:
@@ -434,6 +460,7 @@ All configuration options can be set in `pyproject.toml`:
 ```toml
 [tool.daffy]
 strict = true                    # Enable strict mode by default
+lazy = true                      # Collect all errors before raising (default: false)
 row_validation_max_errors = 5    # Max failed rows to show (default: 5)
 checks_max_samples = 5           # Max sample values in check errors (default: 5)
 ```

--- a/tests/test_lazy_validation.py
+++ b/tests/test_lazy_validation.py
@@ -1,5 +1,7 @@
 """Tests for lazy validation mode."""
 
+from typing import Any
+
 import pandas as pd
 import pytest
 
@@ -22,7 +24,7 @@ class TestLazyValidationDirect:
 
     def test_lazy_true_collects_all_errors(self) -> None:
         df = pd.DataFrame({"a": [1, None], "b": ["x", "y"]})
-        columns = {
+        columns: Any = {
             "a": {"dtype": "float64", "nullable": False},
             "b": {"dtype": "int64"},  # Wrong dtype
             "c": "object",  # Missing column
@@ -37,7 +39,7 @@ class TestLazyValidationDirect:
 
     def test_lazy_true_multiple_errors_separated_by_newlines(self) -> None:
         df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-        columns = {
+        columns: Any = {
             "a": {"dtype": "str"},  # Wrong dtype
             "c": "int64",  # Missing column
         }
@@ -49,13 +51,13 @@ class TestLazyValidationDirect:
 
     def test_lazy_true_no_errors_passes(self) -> None:
         df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
-        columns = {"a": "int64", "b": "float64"}
+        columns: Any = {"a": "int64", "b": "float64"}
         # Should not raise
         validate_dataframe(df, columns, strict=False, lazy=True)
 
     def test_lazy_true_strict_mode_extra_columns(self) -> None:
         df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "extra": [5, 6]})
-        columns = {"a": {"dtype": "str"}}  # Wrong dtype + extra column
+        columns: Any = {"a": {"dtype": "str"}}  # Wrong dtype + extra column
         with pytest.raises(AssertionError) as exc_info:
             validate_dataframe(df, columns, strict=True, lazy=True)
         error = str(exc_info.value)
@@ -64,7 +66,7 @@ class TestLazyValidationDirect:
 
     def test_lazy_includes_check_violations(self) -> None:
         df = pd.DataFrame({"price": [-1, 0, 5]})
-        columns = {
+        columns: Any = {
             "price": {"checks": {"gt": 0}},
             "missing": "int64",  # Missing column
         }
@@ -150,7 +152,7 @@ class TestLazyValidationErrorMessages:
 
     def test_single_error_same_as_non_lazy(self) -> None:
         df = pd.DataFrame({"a": [1, 2]})
-        columns = {"missing": "int64"}
+        columns: Any = {"missing": "int64"}
 
         # Lazy mode with single error
         with pytest.raises(AssertionError) as lazy_exc:
@@ -165,7 +167,7 @@ class TestLazyValidationErrorMessages:
 
     def test_multiple_errors_readable_format(self) -> None:
         df = pd.DataFrame({"a": [1, None], "b": [1, 1]})
-        columns = {
+        columns: Any = {
             "a": {"nullable": False},
             "b": {"unique": True},
             "c": "int64",

--- a/tests/test_lazy_validation.py
+++ b/tests/test_lazy_validation.py
@@ -1,0 +1,179 @@
+"""Tests for lazy validation mode."""
+
+import pandas as pd
+import pytest
+
+from daffy import df_in, df_out
+from daffy.config import clear_config_cache
+from daffy.validation import validate_dataframe
+
+
+class TestLazyValidationDirect:
+    """Test lazy validation via validate_dataframe directly."""
+
+    def test_lazy_false_raises_on_first_error(self) -> None:
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        # Missing column "c" and "d" - should raise on first
+        with pytest.raises(AssertionError) as exc_info:
+            validate_dataframe(df, ["c", "d"], strict=False, lazy=False)
+        assert "Missing columns" in str(exc_info.value)
+        # Should only mention the missing columns, not other errors
+        assert "dtype" not in str(exc_info.value).lower()
+
+    def test_lazy_true_collects_all_errors(self) -> None:
+        df = pd.DataFrame({"a": [1, None], "b": ["x", "y"]})
+        columns = {
+            "a": {"dtype": "float64", "nullable": False},
+            "b": {"dtype": "int64"},  # Wrong dtype
+            "c": "object",  # Missing column
+        }
+        with pytest.raises(AssertionError) as exc_info:
+            validate_dataframe(df, columns, strict=False, lazy=True)
+        error = str(exc_info.value)
+        # Should contain all three types of errors
+        assert "Missing columns" in error
+        assert "wrong dtype" in error
+        assert "null" in error
+
+    def test_lazy_true_multiple_errors_separated_by_newlines(self) -> None:
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        columns = {
+            "a": {"dtype": "str"},  # Wrong dtype
+            "c": "int64",  # Missing column
+        }
+        with pytest.raises(AssertionError) as exc_info:
+            validate_dataframe(df, columns, strict=False, lazy=True)
+        error = str(exc_info.value)
+        # Errors should be separated by double newlines
+        assert "\n\n" in error
+
+    def test_lazy_true_no_errors_passes(self) -> None:
+        df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
+        columns = {"a": "int64", "b": "float64"}
+        # Should not raise
+        validate_dataframe(df, columns, strict=False, lazy=True)
+
+    def test_lazy_true_strict_mode_extra_columns(self) -> None:
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "extra": [5, 6]})
+        columns = {"a": {"dtype": "str"}}  # Wrong dtype + extra column
+        with pytest.raises(AssertionError) as exc_info:
+            validate_dataframe(df, columns, strict=True, lazy=True)
+        error = str(exc_info.value)
+        assert "wrong dtype" in error
+        assert "unexpected column" in error
+
+    def test_lazy_includes_check_violations(self) -> None:
+        df = pd.DataFrame({"price": [-1, 0, 5]})
+        columns = {
+            "price": {"checks": {"gt": 0}},
+            "missing": "int64",  # Missing column
+        }
+        with pytest.raises(AssertionError) as exc_info:
+            validate_dataframe(df, columns, strict=False, lazy=True)
+        error = str(exc_info.value)
+        assert "Missing columns" in error
+        assert "failed check gt" in error
+
+
+class TestLazyValidationDecorators:
+    """Test lazy validation via decorators."""
+
+    def test_df_in_lazy_false_default(self) -> None:
+        @df_in(columns={"a": "str", "b": "int64"})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"a": [1, 2]})  # Missing b, wrong dtype for a
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        error = str(exc_info.value)
+        # Default lazy=False should raise on first error (missing column)
+        assert "Missing columns" in error
+
+    def test_df_in_lazy_true_collects_errors(self) -> None:
+        @df_in(columns={"a": "str", "b": "int64"}, lazy=True)
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"a": [1, 2]})  # Missing b, wrong dtype for a
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        error = str(exc_info.value)
+        # lazy=True should collect both errors
+        assert "Missing columns" in error
+        assert "wrong dtype" in error
+
+    def test_df_out_lazy_true_collects_errors(self) -> None:
+        @df_out(columns={"a": "str", "b": "int64"}, lazy=True)
+        def process() -> pd.DataFrame:
+            return pd.DataFrame({"a": [1, 2]})  # Missing b, wrong dtype for a
+
+        with pytest.raises(AssertionError) as exc_info:
+            process()
+        error = str(exc_info.value)
+        assert "Missing columns" in error
+        assert "wrong dtype" in error
+
+    def test_df_in_lazy_passes_when_valid(self) -> None:
+        @df_in(columns={"a": "int64", "b": "float64"}, lazy=True)
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"a": [1, 2], "b": [1.0, 2.0]})
+        result = process(df)
+        assert len(result) == 2
+
+
+class TestLazyValidationConfig:
+    """Test lazy validation via pyproject.toml config."""
+
+    def setup_method(self) -> None:
+        clear_config_cache()
+
+    def teardown_method(self) -> None:
+        clear_config_cache()
+
+    def test_lazy_defaults_to_false(self) -> None:
+        from daffy.config import get_lazy
+
+        assert get_lazy() is False
+
+    def test_lazy_param_overrides_config(self) -> None:
+        from daffy.config import get_lazy
+
+        assert get_lazy(True) is True
+        assert get_lazy(False) is False
+
+
+class TestLazyValidationErrorMessages:
+    """Test error message formatting in lazy mode."""
+
+    def test_single_error_same_as_non_lazy(self) -> None:
+        df = pd.DataFrame({"a": [1, 2]})
+        columns = {"missing": "int64"}
+
+        # Lazy mode with single error
+        with pytest.raises(AssertionError) as lazy_exc:
+            validate_dataframe(df, columns, strict=False, lazy=True)
+
+        # Non-lazy mode
+        with pytest.raises(AssertionError) as normal_exc:
+            validate_dataframe(df, columns, strict=False, lazy=False)
+
+        # Error messages should be identical for single error
+        assert str(lazy_exc.value) == str(normal_exc.value)
+
+    def test_multiple_errors_readable_format(self) -> None:
+        df = pd.DataFrame({"a": [1, None], "b": [1, 1]})
+        columns = {
+            "a": {"nullable": False},
+            "b": {"unique": True},
+            "c": "int64",
+        }
+        with pytest.raises(AssertionError) as exc_info:
+            validate_dataframe(df, columns, strict=False, lazy=True)
+        error = str(exc_info.value)
+
+        # Each error type should be on its own line(s)
+        lines = error.split("\n\n")
+        assert len(lines) == 3  # missing, nullable, unique


### PR DESCRIPTION
Collect all validation errors before raising with `lazy=True` parameter.

```python
@df_in(columns={
    "price": {"dtype": "float64", "nullable": False},
    "quantity": {"dtype": "int64", "checks": {"gt": 0}},
}, lazy=True)
def process_order(df):
    ...
```

Also configurable via `[tool.daffy] lazy = true` in pyproject.toml.