### PR TITLE
Add composite uniqueness validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
   - Use `@df_in(columns=..., lazy=True)` or `@df_out(columns=..., lazy=True)`
   - Configurable via `[tool.daffy] lazy = true` in pyproject.toml
   - Useful for debugging DataFrames with multiple issues
+- Composite uniqueness: validate that column combinations are unique
+  - Use `composite_unique=[["col1", "col2"]]` to ensure column combinations are unique
+  - Works alongside single-column `unique=True` validation
 
 ## 2.1.0
 

--- a/daffy/dataframe_types.py
+++ b/daffy/dataframe_types.py
@@ -70,3 +70,13 @@ def count_duplicate_values(df: Any, column: str) -> int:
 
     nw_df = nw.from_native(df, eager_only=True)
     return len(nw_df) - nw_df[column].n_unique()
+
+
+def count_duplicate_rows(df: Any, columns: list[str]) -> int:
+    """Count rows with duplicate values across a column combination (excludes first occurrence)."""
+    import narwhals as nw
+
+    nw_df = nw.from_native(df, eager_only=True)
+    total = len(nw_df)
+    unique = nw_df.select(columns).unique().shape[0]
+    return total - unique

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -91,7 +91,13 @@ def df_out(
             assert_is_dataframe(result, "return type")
             if columns or composite_unique:
                 validate_dataframe(
-                    result, columns or [], get_strict(strict), None, func.__name__, True, get_lazy(lazy),
+                    result,
+                    columns or [],
+                    get_strict(strict),
+                    None,
+                    func.__name__,
+                    True,
+                    get_lazy(lazy),
                     composite_unique,
                 )
 
@@ -145,7 +151,13 @@ def df_in(
             assert_is_dataframe(df, "parameter type")
             if columns or composite_unique:
                 validate_dataframe(
-                    df, columns or [], get_strict(strict), param_name, func.__name__, False, get_lazy(lazy),
+                    df,
+                    columns or [],
+                    get_strict(strict),
+                    param_name,
+                    func.__name__,
+                    False,
+                    get_lazy(lazy),
                     composite_unique,
                 )
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -134,6 +134,41 @@ If a column contains duplicate values when `unique=True`, an error is raised:
 AssertionError: Column 'user_id' in function 'process_users' parameter 'df' contains 5 duplicate values but unique=True
 ```
 
+## Composite Uniqueness
+
+For validating that combinations of columns are unique (like a composite primary key), use `composite_unique`:
+
+```python
+@df_in(composite_unique=[["first_name", "last_name"]])
+def process_users(df):
+    # The combination of first_name + last_name must be unique
+    ...
+```
+
+### Multiple Constraints
+
+You can specify multiple composite uniqueness constraints:
+
+```python
+@df_in(
+    columns={"email": {"unique": True}},  # Single column unique
+    composite_unique=[
+        ["first_name", "last_name"],      # Name combo must be unique
+        ["department", "employee_id"],     # Dept + ID must be unique
+    ]
+)
+def process_data(df):
+    ...
+```
+
+### Error Messages
+
+When composite uniqueness fails, you get an error like:
+
+```
+AssertionError: Columns 'first_name' + 'last_name' in function 'process_users' parameter 'df' contain 5 duplicate combinations but composite_unique is set
+```
+
 ## Optional Columns
 
 By default, all specified columns are required. You can mark columns as optional using `required=False`:

--- a/tests/test_composite_unique.py
+++ b/tests/test_composite_unique.py
@@ -1,0 +1,156 @@
+"""Tests for composite uniqueness validation."""
+
+import pandas as pd
+import pytest
+
+from daffy import df_in, df_out
+from daffy.dataframe_types import count_duplicate_rows
+
+
+class TestCountDuplicateRows:
+    def test_no_duplicates(self) -> None:
+        df = pd.DataFrame({
+            "first": ["A", "A", "B"],
+            "last": ["X", "Y", "X"],
+        })
+        assert count_duplicate_rows(df, ["first", "last"]) == 0
+
+    def test_with_duplicates(self) -> None:
+        df = pd.DataFrame({
+            "first": ["A", "A", "A"],
+            "last": ["X", "X", "Y"],
+        })
+        # Row 0 and 1 are duplicates (A, X)
+        assert count_duplicate_rows(df, ["first", "last"]) == 1
+
+    def test_all_duplicates(self) -> None:
+        df = pd.DataFrame({
+            "a": [1, 1, 1],
+            "b": [2, 2, 2],
+        })
+        # All rows are duplicates, 2 extra after first
+        assert count_duplicate_rows(df, ["a", "b"]) == 2
+
+    def test_single_column(self) -> None:
+        df = pd.DataFrame({"a": [1, 1, 2]})
+        assert count_duplicate_rows(df, ["a"]) == 1
+
+    def test_empty_dataframe(self) -> None:
+        df = pd.DataFrame({"a": [], "b": []})
+        assert count_duplicate_rows(df, ["a", "b"]) == 0
+
+
+class TestCompositeUniqueDecorators:
+    def test_df_in_composite_unique_passes(self) -> None:
+        @df_in(composite_unique=[["first", "last"]])
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({
+            "first": ["A", "A", "B"],
+            "last": ["X", "Y", "X"],
+        })
+        result = process(df)
+        assert len(result) == 3
+
+    def test_df_in_composite_unique_fails(self) -> None:
+        @df_in(composite_unique=[["first", "last"]])
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({
+            "first": ["A", "A", "B"],
+            "last": ["X", "X", "X"],  # A+X appears twice
+        })
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        assert "composite_unique" in str(exc_info.value)
+        assert "'first' + 'last'" in str(exc_info.value)
+
+    def test_df_out_composite_unique_passes(self) -> None:
+        @df_out(composite_unique=[["a", "b"]])
+        def create() -> pd.DataFrame:
+            return pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+        result = create()
+        assert len(result) == 2
+
+    def test_df_out_composite_unique_fails(self) -> None:
+        @df_out(composite_unique=[["a", "b"]])
+        def create() -> pd.DataFrame:
+            return pd.DataFrame({"a": [1, 1], "b": [2, 2]})
+
+        with pytest.raises(AssertionError) as exc_info:
+            create()
+        assert "composite_unique" in str(exc_info.value)
+
+    def test_multiple_composite_unique_constraints(self) -> None:
+        @df_in(composite_unique=[["a", "b"], ["c", "d"]])
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        # First constraint passes, second fails
+        df = pd.DataFrame({
+            "a": [1, 2],
+            "b": [3, 4],
+            "c": [1, 1],
+            "d": [2, 2],
+        })
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        assert "'c' + 'd'" in str(exc_info.value)
+
+    def test_composite_unique_with_columns(self) -> None:
+        @df_in(
+            columns={"a": "int64", "b": "int64"},
+            composite_unique=[["a", "b"]],
+        )
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        result = process(df)
+        assert len(result) == 2
+
+    def test_composite_unique_only_no_columns(self) -> None:
+        @df_in(composite_unique=[["x", "y"]])
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]})
+        result = process(df)
+        assert len(result) == 2
+
+    def test_error_message_includes_count(self) -> None:
+        @df_in(composite_unique=[["a", "b"]])
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({
+            "a": [1, 1, 1, 2],
+            "b": [2, 2, 2, 3],
+        })  # 2 duplicate rows
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        assert "2 duplicate combinations" in str(exc_info.value)
+
+
+class TestCompositeUniqueWithLazy:
+    def test_lazy_collects_composite_unique_errors(self) -> None:
+        @df_in(
+            columns={"missing": "int64"},
+            composite_unique=[["a", "b"]],
+            lazy=True,
+        )
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({
+            "a": [1, 1],
+            "b": [2, 2],
+        })
+        with pytest.raises(AssertionError) as exc_info:
+            process(df)
+        error = str(exc_info.value)
+        assert "Missing columns" in error
+        assert "composite_unique" in error

--- a/tests/test_composite_unique.py
+++ b/tests/test_composite_unique.py
@@ -9,25 +9,31 @@ from daffy.dataframe_types import count_duplicate_rows
 
 class TestCountDuplicateRows:
     def test_no_duplicates(self) -> None:
-        df = pd.DataFrame({
-            "first": ["A", "A", "B"],
-            "last": ["X", "Y", "X"],
-        })
+        df = pd.DataFrame(
+            {
+                "first": ["A", "A", "B"],
+                "last": ["X", "Y", "X"],
+            }
+        )
         assert count_duplicate_rows(df, ["first", "last"]) == 0
 
     def test_with_duplicates(self) -> None:
-        df = pd.DataFrame({
-            "first": ["A", "A", "A"],
-            "last": ["X", "X", "Y"],
-        })
+        df = pd.DataFrame(
+            {
+                "first": ["A", "A", "A"],
+                "last": ["X", "X", "Y"],
+            }
+        )
         # Row 0 and 1 are duplicates (A, X)
         assert count_duplicate_rows(df, ["first", "last"]) == 1
 
     def test_all_duplicates(self) -> None:
-        df = pd.DataFrame({
-            "a": [1, 1, 1],
-            "b": [2, 2, 2],
-        })
+        df = pd.DataFrame(
+            {
+                "a": [1, 1, 1],
+                "b": [2, 2, 2],
+            }
+        )
         # All rows are duplicates, 2 extra after first
         assert count_duplicate_rows(df, ["a", "b"]) == 2
 
@@ -46,10 +52,12 @@ class TestCompositeUniqueDecorators:
         def process(df: pd.DataFrame) -> pd.DataFrame:
             return df
 
-        df = pd.DataFrame({
-            "first": ["A", "A", "B"],
-            "last": ["X", "Y", "X"],
-        })
+        df = pd.DataFrame(
+            {
+                "first": ["A", "A", "B"],
+                "last": ["X", "Y", "X"],
+            }
+        )
         result = process(df)
         assert len(result) == 3
 
@@ -58,10 +66,12 @@ class TestCompositeUniqueDecorators:
         def process(df: pd.DataFrame) -> pd.DataFrame:
             return df
 
-        df = pd.DataFrame({
-            "first": ["A", "A", "B"],
-            "last": ["X", "X", "X"],  # A+X appears twice
-        })
+        df = pd.DataFrame(
+            {
+                "first": ["A", "A", "B"],
+                "last": ["X", "X", "X"],  # A+X appears twice
+            }
+        )
         with pytest.raises(AssertionError) as exc_info:
             process(df)
         assert "composite_unique" in str(exc_info.value)
@@ -90,12 +100,14 @@ class TestCompositeUniqueDecorators:
             return df
 
         # First constraint passes, second fails
-        df = pd.DataFrame({
-            "a": [1, 2],
-            "b": [3, 4],
-            "c": [1, 1],
-            "d": [2, 2],
-        })
+        df = pd.DataFrame(
+            {
+                "a": [1, 2],
+                "b": [3, 4],
+                "c": [1, 1],
+                "d": [2, 2],
+            }
+        )
         with pytest.raises(AssertionError) as exc_info:
             process(df)
         assert "'c' + 'd'" in str(exc_info.value)
@@ -126,10 +138,12 @@ class TestCompositeUniqueDecorators:
         def process(df: pd.DataFrame) -> pd.DataFrame:
             return df
 
-        df = pd.DataFrame({
-            "a": [1, 1, 1, 2],
-            "b": [2, 2, 2, 3],
-        })  # 2 duplicate rows
+        df = pd.DataFrame(
+            {
+                "a": [1, 1, 1, 2],
+                "b": [2, 2, 2, 3],
+            }
+        )  # 2 duplicate rows
         with pytest.raises(AssertionError) as exc_info:
             process(df)
         assert "2 duplicate combinations" in str(exc_info.value)
@@ -145,10 +159,12 @@ class TestCompositeUniqueWithLazy:
         def process(df: pd.DataFrame) -> pd.DataFrame:
             return df
 
-        df = pd.DataFrame({
-            "a": [1, 1],
-            "b": [2, 2],
-        })
+        df = pd.DataFrame(
+            {
+                "a": [1, 1],
+                "b": [2, 2],
+            }
+        )
         with pytest.raises(AssertionError) as exc_info:
             process(df)
         error = str(exc_info.value)


### PR DESCRIPTION
Validate that column combinations are unique with `composite_unique` parameter.

```python
@df_in(composite_unique=[["first_name", "last_name"]])
def process_users(df):
    # The combination of first_name + last_name must be unique
    ...
```

Works alongside single-column `unique=True` validation and supports multiple constraints.