### PR TITLE
Replace abandoned deadcode with vulture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,12 +58,12 @@ jobs:
         run: |
           uv sync --group test --group dev
 
-      - name: Lint with Ruff, Pyrefly, and Deadcode
+      - name: Lint with Ruff, Pyrefly, and Vulture
         run: |
           uv run ruff check --output-format=github .
           uv run ruff format --diff
           uv run pyrefly check .
-          uv run deadcode daffy/
+          uv run vulture
 
   # Coverage on latest Python only
   coverage:

--- a/daffy/__init__.py
+++ b/daffy/__init__.py
@@ -6,7 +6,8 @@ annotate your functions so that they document themselves and that documentation 
 the input and output on runtime.
 """
 
+from .checks import CheckName
 from .decorators import df_in, df_log, df_out
 from .validation import ColumnConstraints
 
-__all__ = ["df_in", "df_out", "df_log", "ColumnConstraints"]
+__all__ = ["df_in", "df_out", "df_log", "ColumnConstraints", "CheckName"]

--- a/daffy/checks.py
+++ b/daffy/checks.py
@@ -10,7 +10,6 @@ from typing import Any, Literal
 
 import narwhals as nw
 
-# Built-in check names for type safety
 CheckName = Literal[
     "gt",
     "ge",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = [
 dev = [
     "ruff==0.14.10",
     "pyrefly==0.46.0",
-    "deadcode==2.4.1; python_version >= '3.10'",
+    "vulture==2.14",
     "coverage[toml]==7.13.1; python_version >= '3.10'",
     "pytest-cov==7.0.0",
     "pre-commit==4.5.0; python_version >= '3.10'",
@@ -124,6 +124,7 @@ python-version = "3.10"
 untyped-def-behavior = "check-and-infer-return-any"
 permissive-ignores = true
 
-[tool.deadcode]
-exclude = [".venv", "tests", "scripts"]
-ignore-names = ["clear_config_cache"]
+[tool.vulture]
+paths = ["daffy"]
+exclude = [".venv/", "tests/", "scripts/"]
+ignore_names = ["clear_config_cache"]

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "matchDepNames": [
         "ruff",
         "pyrefly",
-        "deadcode",
+        "vulture",
         "coverage",
         "pytest-cov",
         "pre-commit",


### PR DESCRIPTION
## Summary
- Replace `deadcode` (abandoned) with `vulture` (actively maintained) for dead code detection
- `vulture` supports Python 3.8+, removing the Python 3.10+ constraint that `deadcode` required
- Export `CheckName` type alias as public API - vulture correctly identified it as unused dead code