### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
 
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v6
 
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
         scenario: ["pandas-only", "polars-only", "both", "pandas-no-pydantic", "none"]
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.3.0
+
+### Breaking Changes
+
+- **Dropped Python 3.9 support** - Python 3.10 is now the minimum required version (Python 3.9 reached end-of-life in October 2025)
+
+### Internal Improvements
+
+- Modernized type annotations using Python 3.10 syntax (`X | Y` instead of `Union[X, Y]`, explicit `TypeAlias`)
+- Updated ruff target version to Python 3.10
+
 ## 2.2.0
 
 ### New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ For testing with isolated optional dependencies, see `TESTING_OPTIONAL_DEPS.md`.
 
 ## Key Constraints
 
-- Python 3.9+ compatibility
+- Python 3.10+ compatibility
 - DataFrame libraries are optional - only narwhals is required
 - 100% test coverage
 - Avoid obvious comments - use good names instead

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or with conda:
 conda install -c conda-forge daffy
 ```
 
-Works with whatever DataFrame library you already have installed. Python 3.9–3.14.
+Works with whatever DataFrame library you already have installed. Python 3.10–3.14.
 
 ---
 

--- a/daffy/dataframe_types.py
+++ b/daffy/dataframe_types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, TypeAlias, Union
 
 import narwhals as nw
 
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from pandas import DataFrame as PandasDataFrame
     from polars import DataFrame as PolarsDataFrame
 
-    DataFrameType = Union[PandasDataFrame, PolarsDataFrame]
+    DataFrameType: TypeAlias = PandasDataFrame | PolarsDataFrame
 else:
     # For runtime, build type tuple from available libraries
     _available_types = []

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Any, TypedDict, Union
+from typing import Any, TypeAlias, TypedDict
 
 import narwhals as nw
 
@@ -36,9 +36,9 @@ class ColumnConstraints(TypedDict, total=False):
     checks: dict[str, Any]
 
 
-ColumnsList = Sequence[Union[str, RegexColumnDef]]
-ColumnsDict = dict[Union[str, RegexColumnDef], Any]
-ColumnsDef = Union[ColumnsList, ColumnsDict, None]
+ColumnsList: TypeAlias = Sequence[str | RegexColumnDef]
+ColumnsDict: TypeAlias = dict[str | RegexColumnDef, Any]
+ColumnsDef: TypeAlias = ColumnsList | ColumnsDict | None
 
 
 def _get_columns_to_check(column_spec: str | RegexColumnDef, df_columns: list[str]) -> list[str]:

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ If a column is missing, has wrong dtype, or violates a constraint — **Daffy fa
     conda install -c conda-forge daffy
     ```
 
-Works with whatever DataFrame library you already have installed. Python 3.9–3.14.
+Works with whatever DataFrame library you already have installed. Python 3.10–3.14.
 
 ## Why Daffy?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "2.2.0"
+version = "2.3.0"
 description = "Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow."
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },
 ]
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 keywords = ["pandas", "polars", "modin", "pyarrow", "narwhals", "pydantic", "dataframe", "decorator", "validation", "schema", "data-validation", "typing", "data-quality", "column-validation", "dataframe-schema", "row-validation", "runtime-validation", "data-pipeline", "pandas-validation", "polars-validation", "validate-dataframe", "dataframe-validator"]
 classifiers = [
@@ -15,7 +15,6 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -42,15 +41,13 @@ changelog = "https://github.com/vertti/daffy/blob/master/CHANGELOG.md"
 issues = "https://github.com/vertti/daffy/issues"
 
 [dependency-groups]
-# Minimal dependencies for running tests - must support Python 3.9+
 test = [
-    "pytest==8.4.2; python_version < '3.10'",
-    "pytest==9.0.2; python_version >= '3.10'",
+    "pytest==9.0.2",
     "pytest-mock==3.15.1",
     "pandas>=1.5.1,<3.0.0",
     "polars>=1.7.0",
     "pydantic>=2.4.0",
-    "modin[ray]>=0.30.0; python_version >= '3.10' and python_version < '3.14'",
+    "modin[ray]>=0.30.0; python_version < '3.14'",
     "pyarrow>=14.0.0",
 ]
 
@@ -59,9 +56,9 @@ dev = [
     "ruff==0.14.10",
     "pyrefly==0.46.0",
     "vulture==2.14",
-    "coverage[toml]==7.13.1; python_version >= '3.10'",
+    "coverage[toml]==7.13.1",
     "pytest-cov==7.0.0",
-    "pre-commit==4.5.1; python_version >= '3.10'",
+    "pre-commit==4.5.1",
     "pydocstyle==6.3.0",
 ]
 
@@ -111,7 +108,7 @@ testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["F", "E", "W", "I", "N", "ANN"]

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "mode": "full",
   "prHourlyLimit": 10,
   "constraints": {
-    "python": ">=3.9"
+    "python": ">=3.10"
   },
   "ignoreDeps": ["tomli", "narwhals"],
   "packageRules": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
-from typing import Any, Callable, Union
+from typing import Any, Callable, TypeAlias
 
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
 
-DataFrameType = Union[pd.DataFrame, pl.DataFrame]
+DataFrameType: TypeAlias = pd.DataFrame | pl.DataFrame
 
 
 def make_pandas_df(data: dict[str, Any]) -> pd.DataFrame:


### PR DESCRIPTION
## Summary

- Drop Python 3.9 support (EOL October 2025)
- Bump version to 2.3.0
- Modernize type annotations using Python 3.10 syntax

## Changes

- Update `requires-python` to `>=3.10`
- Remove Python 3.9 from CI test matrix
- Use `X | Y` instead of `Union[X, Y]` for type annotations
- Add explicit `TypeAlias` annotations
- Update ruff target version to `py310`
- Update documentation references