### PR TITLE
Add shape validation (min_rows, max_rows, exact_rows, allow_empty)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.4.0
+
+### New Features
+
+- **Shape validation**: enforce row count constraints on DataFrames
+  - `min_rows`: require a minimum number of rows
+  - `max_rows`: limit the maximum number of rows
+  - `exact_rows`: require an exact number of rows
+  - `allow_empty`: control whether empty DataFrames (0 rows) are allowed
+- New `allow_empty` configuration option in `pyproject.toml` (default: `true`)
+
 ## 2.3.1
 
 ### Bug Fixes

--- a/daffy/config.py
+++ b/daffy/config.py
@@ -14,12 +14,14 @@ _KEY_STRICT = "strict"
 _KEY_LAZY = "lazy"
 _KEY_ROW_VALIDATION_MAX_ERRORS = "row_validation_max_errors"
 _KEY_CHECKS_MAX_SAMPLES = "checks_max_samples"
+_KEY_ALLOW_EMPTY = "allow_empty"
 
 # Default values
 _DEFAULT_STRICT = False
 _DEFAULT_LAZY = False
 _DEFAULT_MAX_ERRORS = 5
 _DEFAULT_CHECKS_MAX_SAMPLES = 5
+_DEFAULT_ALLOW_EMPTY = True
 
 
 def _validate_bool_config(daffy_config: dict[str, Any], key: str) -> bool | None:
@@ -62,6 +64,7 @@ def load_config() -> dict[str, Any]:
         _KEY_LAZY: _DEFAULT_LAZY,
         _KEY_ROW_VALIDATION_MAX_ERRORS: _DEFAULT_MAX_ERRORS,
         _KEY_CHECKS_MAX_SAMPLES: _DEFAULT_CHECKS_MAX_SAMPLES,
+        _KEY_ALLOW_EMPTY: _DEFAULT_ALLOW_EMPTY,
     }
 
     # Try to find pyproject.toml in the current directory or parent directories
@@ -92,6 +95,10 @@ def load_config() -> dict[str, Any]:
         max_samples = _validate_int_config(daffy_config, _KEY_CHECKS_MAX_SAMPLES)
         if max_samples is not None:
             default_config[_KEY_CHECKS_MAX_SAMPLES] = max_samples
+
+        allow_empty = _validate_bool_config(daffy_config, _KEY_ALLOW_EMPTY)
+        if allow_empty is not None:
+            default_config[_KEY_ALLOW_EMPTY] = allow_empty
 
         return default_config
     except (FileNotFoundError, tomli.TOMLDecodeError):
@@ -168,3 +175,19 @@ def get_checks_max_samples(max_samples: int | None = None) -> int:
     if value < 1:
         raise ValueError(f"checks_max_samples must be >= 1, got {value}")
     return value
+
+
+def get_allow_empty(allow_empty_param: bool | None = None) -> bool:
+    """Get the allow_empty setting, with explicit parameter taking precedence over configuration.
+
+    When allow_empty=False, empty DataFrames (0 rows) will raise an error.
+
+    Args:
+        allow_empty_param: Explicitly provided allow_empty parameter value, or None to use config
+
+    Returns:
+        bool: The effective allow_empty setting
+    """
+    if allow_empty_param is not None:
+        return allow_empty_param
+    return bool(get_config()[_KEY_ALLOW_EMPTY])

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -69,6 +69,7 @@ def df_out(
     composite_unique: list[list[str]] | None = None,
     row_validator: "type[BaseModel] | None" = None,
     min_rows: int | None = None,
+    max_rows: int | None = None,
 ) -> Callable[[Callable[..., IntoDataFrameT]], Callable[..., IntoDataFrameT]]:
     """Decorate a function that returns a DataFrame (Pandas, Polars, Modin, or PyArrow).
 
@@ -89,6 +90,7 @@ def df_out(
         row_validator (type[BaseModel], optional): Pydantic model for validating row data.
             Requires pydantic >= 2.4.0. Defaults to None.
         min_rows (int, optional): Minimum number of rows required. Defaults to None (no minimum).
+        max_rows (int, optional): Maximum number of rows allowed. Defaults to None (no maximum).
 
     Returns:
         Callable: Decorated function with preserved DataFrame return type
@@ -104,8 +106,8 @@ def df_out(
             func_name = getattr(func, "__name__", "<unknown>")
             param_info = format_param_context(None, func_name, is_return_value=True)
 
-            if min_rows is not None:
-                validate_shape(result, min_rows, param_info)
+            if min_rows is not None or max_rows is not None:
+                validate_shape(result, min_rows, max_rows, param_info)
 
             if columns or composite_unique:
                 validate_dataframe(
@@ -137,6 +139,7 @@ def df_in(
     composite_unique: list[list[str]] | None = None,
     row_validator: "type[BaseModel] | None" = None,
     min_rows: int | None = None,
+    max_rows: int | None = None,
 ) -> Callable[[Callable[..., InReturnT]], Callable[..., InReturnT]]:
     """Decorate a function parameter that is a DataFrame (Pandas, Polars, Modin, or PyArrow).
 
@@ -158,6 +161,7 @@ def df_in(
         row_validator (type[BaseModel], optional): Pydantic model for validating row data.
             Requires pydantic >= 2.4.0. Defaults to None.
         min_rows (int, optional): Minimum number of rows required. Defaults to None (no minimum).
+        max_rows (int, optional): Maximum number of rows allowed. Defaults to None (no maximum).
 
     Returns:
         Callable: Decorated function with preserved return type
@@ -174,8 +178,8 @@ def df_in(
             func_name = getattr(func, "__name__", "<unknown>")
             param_info = format_param_context(param_name, func_name, is_return_value=False)
 
-            if min_rows is not None:
-                validate_shape(df, min_rows, param_info)
+            if min_rows is not None or max_rows is not None:
+                validate_shape(df, min_rows, max_rows, param_info)
 
             if columns or composite_unique:
                 validate_dataframe(

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -42,6 +42,22 @@ def _validate_composite_unique(composite_unique: list[list[str]] | None) -> None
                 raise TypeError(f"composite_unique[{i}][{j}] must be a string, got {type(col).__name__}")
 
 
+def _validate_shape_constraints(
+    min_rows: int | None,
+    max_rows: int | None,
+    exact_rows: int | None,
+) -> None:
+    """Validate shape constraint parameters at decorator time."""
+    if min_rows is not None and min_rows < 0:
+        raise ValueError(f"min_rows must be >= 0, got {min_rows}")
+    if max_rows is not None and max_rows < 0:
+        raise ValueError(f"max_rows must be >= 0, got {max_rows}")
+    if exact_rows is not None and exact_rows < 0:
+        raise ValueError(f"exact_rows must be >= 0, got {exact_rows}")
+    if min_rows is not None and max_rows is not None and min_rows > max_rows:
+        raise ValueError(f"min_rows ({min_rows}) cannot be greater than max_rows ({max_rows})")
+
+
 # Type variables for preserving return types
 LogReturnT = TypeVar("LogReturnT")  # Return type for df_log
 InReturnT = TypeVar("InReturnT")  # Return type for df_in
@@ -101,6 +117,7 @@ def df_out(
         Callable: Decorated function with preserved DataFrame return type
     """
     _validate_composite_unique(composite_unique)
+    _validate_shape_constraints(min_rows, max_rows, exact_rows)
 
     def wrapper_df_out(func: Callable[..., IntoDataFrameT]) -> Callable[..., IntoDataFrameT]:
         @wraps(func)
@@ -190,6 +207,7 @@ def df_in(
         Callable: Decorated function with preserved return type
     """
     _validate_composite_unique(composite_unique)
+    _validate_shape_constraints(min_rows, max_rows, exact_rows)
 
     def wrapper_df_in(func: Callable[..., InReturnT]) -> Callable[..., InReturnT]:
         @wraps(func)

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -70,6 +70,7 @@ def df_out(
     row_validator: "type[BaseModel] | None" = None,
     min_rows: int | None = None,
     max_rows: int | None = None,
+    exact_rows: int | None = None,
 ) -> Callable[[Callable[..., IntoDataFrameT]], Callable[..., IntoDataFrameT]]:
     """Decorate a function that returns a DataFrame (Pandas, Polars, Modin, or PyArrow).
 
@@ -91,6 +92,7 @@ def df_out(
             Requires pydantic >= 2.4.0. Defaults to None.
         min_rows (int, optional): Minimum number of rows required. Defaults to None (no minimum).
         max_rows (int, optional): Maximum number of rows allowed. Defaults to None (no maximum).
+        exact_rows (int, optional): Exact number of rows required. Defaults to None (no constraint).
 
     Returns:
         Callable: Decorated function with preserved DataFrame return type
@@ -106,8 +108,8 @@ def df_out(
             func_name = getattr(func, "__name__", "<unknown>")
             param_info = format_param_context(None, func_name, is_return_value=True)
 
-            if min_rows is not None or max_rows is not None:
-                validate_shape(result, min_rows, max_rows, param_info)
+            if min_rows is not None or max_rows is not None or exact_rows is not None:
+                validate_shape(result, min_rows, max_rows, exact_rows, param_info)
 
             if columns or composite_unique:
                 validate_dataframe(
@@ -140,6 +142,7 @@ def df_in(
     row_validator: "type[BaseModel] | None" = None,
     min_rows: int | None = None,
     max_rows: int | None = None,
+    exact_rows: int | None = None,
 ) -> Callable[[Callable[..., InReturnT]], Callable[..., InReturnT]]:
     """Decorate a function parameter that is a DataFrame (Pandas, Polars, Modin, or PyArrow).
 
@@ -162,6 +165,7 @@ def df_in(
             Requires pydantic >= 2.4.0. Defaults to None.
         min_rows (int, optional): Minimum number of rows required. Defaults to None (no minimum).
         max_rows (int, optional): Maximum number of rows allowed. Defaults to None (no maximum).
+        exact_rows (int, optional): Exact number of rows required. Defaults to None (no constraint).
 
     Returns:
         Callable: Decorated function with preserved return type
@@ -178,8 +182,8 @@ def df_in(
             func_name = getattr(func, "__name__", "<unknown>")
             param_info = format_param_context(param_name, func_name, is_return_value=False)
 
-            if min_rows is not None or max_rows is not None:
-                validate_shape(df, min_rows, max_rows, param_info)
+            if min_rows is not None or max_rows is not None or exact_rows is not None:
+                validate_shape(df, min_rows, max_rows, exact_rows, param_info)
 
             if columns or composite_unique:
                 validate_dataframe(

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -26,6 +26,7 @@ def validate_shape(
     df: Any,
     min_rows: int | None,
     max_rows: int | None,
+    exact_rows: int | None,
     param_info: str,
 ) -> None:
     """Validate DataFrame shape constraints.
@@ -34,16 +35,20 @@ def validate_shape(
         df: DataFrame to validate
         min_rows: Minimum required row count (None means no constraint)
         max_rows: Maximum allowed row count (None means no constraint)
+        exact_rows: Exact required row count (None means no constraint)
         param_info: Parameter context string for error messages
 
     Raises:
         AssertionError: If validation fails
     """
-    if min_rows is None and max_rows is None:
+    if min_rows is None and max_rows is None and exact_rows is None:
         return
 
     nw_df = nw.from_native(df, eager_only=True)
     row_count = nw_df.shape[0]
+
+    if exact_rows is not None and row_count != exact_rows:
+        raise AssertionError(f"DataFrame{param_info} has {row_count} rows but exact_rows={exact_rows}")
 
     if min_rows is not None and row_count < min_rows:
         raise AssertionError(f"DataFrame{param_info} has {row_count} rows but min_rows={min_rows}")

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -25,6 +25,7 @@ from daffy.utils import describe_dataframe, format_param_context
 def validate_shape(
     df: Any,
     min_rows: int | None,
+    max_rows: int | None,
     param_info: str,
 ) -> None:
     """Validate DataFrame shape constraints.
@@ -32,19 +33,23 @@ def validate_shape(
     Args:
         df: DataFrame to validate
         min_rows: Minimum required row count (None means no constraint)
+        max_rows: Maximum allowed row count (None means no constraint)
         param_info: Parameter context string for error messages
 
     Raises:
         AssertionError: If validation fails
     """
-    if min_rows is None:
+    if min_rows is None and max_rows is None:
         return
 
     nw_df = nw.from_native(df, eager_only=True)
     row_count = nw_df.shape[0]
 
-    if row_count < min_rows:
+    if min_rows is not None and row_count < min_rows:
         raise AssertionError(f"DataFrame{param_info} has {row_count} rows but min_rows={min_rows}")
+
+    if max_rows is not None and row_count > max_rows:
+        raise AssertionError(f"DataFrame{param_info} has {row_count} rows but max_rows={max_rows}")
 
 
 class ColumnConstraints(TypedDict, total=False):

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -22,6 +22,31 @@ from daffy.patterns import (
 from daffy.utils import describe_dataframe, format_param_context
 
 
+def validate_shape(
+    df: Any,
+    min_rows: int | None,
+    param_info: str,
+) -> None:
+    """Validate DataFrame shape constraints.
+
+    Args:
+        df: DataFrame to validate
+        min_rows: Minimum required row count (None means no constraint)
+        param_info: Parameter context string for error messages
+
+    Raises:
+        AssertionError: If validation fails
+    """
+    if min_rows is None:
+        return
+
+    nw_df = nw.from_native(df, eager_only=True)
+    row_count = nw_df.shape[0]
+
+    if row_count < min_rows:
+        raise AssertionError(f"DataFrame{param_info} has {row_count} rows but min_rows={min_rows}")
+
+
 class ColumnConstraints(TypedDict, total=False):
     """Type-safe specification for column constraints.
 

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -27,6 +27,7 @@ def validate_shape(
     min_rows: int | None,
     max_rows: int | None,
     exact_rows: int | None,
+    allow_empty: bool,
     param_info: str,
 ) -> None:
     """Validate DataFrame shape constraints.
@@ -36,16 +37,17 @@ def validate_shape(
         min_rows: Minimum required row count (None means no constraint)
         max_rows: Maximum allowed row count (None means no constraint)
         exact_rows: Exact required row count (None means no constraint)
+        allow_empty: Whether empty DataFrames (0 rows) are allowed
         param_info: Parameter context string for error messages
 
     Raises:
         AssertionError: If validation fails
     """
-    if min_rows is None and max_rows is None and exact_rows is None:
-        return
-
     nw_df = nw.from_native(df, eager_only=True)
     row_count = nw_df.shape[0]
+
+    if not allow_empty and row_count == 0:
+        raise AssertionError(f"DataFrame{param_info} is empty but allow_empty=False")
 
     if exact_rows is not None and row_count != exact_rows:
         raise AssertionError(f"DataFrame{param_info} has {row_count} rows but exact_rows={exact_rows}")

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -171,6 +171,65 @@ When composite uniqueness fails, you get an error like:
 AssertionError: Columns 'first_name' + 'last_name' in function 'process_users' parameter 'df' contain 5 duplicate combinations but composite_unique is set
 ```
 
+## Shape Validation
+
+Enforce row count constraints on your DataFrames.
+
+### Minimum Rows
+
+Require a minimum number of rows:
+
+```python
+@df_in(min_rows=1)  # Reject empty DataFrames
+def process_data(df):
+    ...
+
+@df_out(min_rows=10)  # Ensure at least 10 rows are returned
+def get_results():
+    ...
+```
+
+### Maximum Rows
+
+Limit the maximum number of rows:
+
+```python
+@df_in(max_rows=1000)  # Reject DataFrames with more than 1000 rows
+def process_batch(df):
+    ...
+```
+
+### Exact Row Count
+
+Require an exact number of rows:
+
+```python
+@df_in(exact_rows=5)  # Require exactly 5 rows
+def process_lookup_table(df):
+    ...
+```
+
+### Combining Constraints
+
+```python
+@df_out(min_rows=10, max_rows=100)  # Between 10 and 100 rows
+def transform_data(df):
+    ...
+```
+
+### Error Messages
+
+```
+# min_rows violation
+AssertionError: DataFrame in function 'process_data' parameter 'df' has 0 rows but min_rows=1
+
+# max_rows violation
+AssertionError: DataFrame in function 'process_data' return value has 150 rows but max_rows=100
+
+# exact_rows violation
+AssertionError: DataFrame in function 'process_data' parameter 'df' has 8 rows but exact_rows=5
+```
+
 ## Optional Columns
 
 By default, all specified columns are required. You can mark columns as optional using `required=False`:
@@ -499,6 +558,23 @@ All configuration options can be set in `pyproject.toml`:
 [tool.daffy]
 strict = true                    # Enable strict mode by default
 lazy = true                      # Collect all errors before raising (default: false)
+allow_empty = false              # Reject empty DataFrames by default (default: true)
 row_validation_max_errors = 5    # Max failed rows to show (default: 5)
 checks_max_samples = 5           # Max sample values in check errors (default: 5)
+```
+
+### allow_empty
+
+When set to `false`, all DataFrames will be rejected if they have 0 rows:
+
+```python
+# With allow_empty=false in config, this will raise:
+@df_in()
+def process(df):  # Raises if df is empty
+    ...
+
+# Override for specific decorators:
+@df_in(allow_empty=True)  # Allow empty even if config says false
+def optional_process(df):
+    ...
 ```

--- a/tests/test_shape_validation.py
+++ b/tests/test_shape_validation.py
@@ -114,3 +114,89 @@ class TestMinRowsDfIn:
 
         with pytest.raises(AssertionError, match=r"parameter 'df'"):
             f(make_df({"a": [1]}))
+
+
+class TestMaxRowsDfOut:
+    def test_max_rows_rejects_too_many_rows(self, make_df: DataFrameFactory) -> None:
+        @df_out(max_rows=2)
+        def f() -> Any:
+            return make_df({"a": [1, 2, 3, 4]})
+
+        with pytest.raises(AssertionError, match=r"has 4 rows but max_rows=2"):
+            f()
+
+    def test_max_rows_passes_exact_count(self, make_df: DataFrameFactory) -> None:
+        @df_out(max_rows=3)
+        def f() -> Any:
+            return make_df({"a": [1, 2, 3]})
+
+        result = f()
+        assert len(result) == 3
+
+    def test_max_rows_passes_fewer_than_maximum(self, make_df: DataFrameFactory) -> None:
+        @df_out(max_rows=10)
+        def f() -> Any:
+            return make_df({"a": [1, 2]})
+
+        result = f()
+        assert len(result) == 2
+
+    def test_max_rows_allows_empty_dataframe(self, make_df: DataFrameFactory) -> None:
+        @df_out(max_rows=5)
+        def f() -> Any:
+            return make_df({"a": []})
+
+        result = f()
+        assert len(result) == 0
+
+
+class TestMaxRowsDfIn:
+    def test_max_rows_rejects_too_many_rows(self, make_df: DataFrameFactory) -> None:
+        @df_in(max_rows=2)
+        def f(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match=r"has 4 rows but max_rows=2"):
+            f(make_df({"a": [1, 2, 3, 4]}))
+
+    def test_max_rows_passes_exact_count(self, make_df: DataFrameFactory) -> None:
+        @df_in(max_rows=3)
+        def f(df: Any) -> Any:
+            return df
+
+        result = f(make_df({"a": [1, 2, 3]}))
+        assert len(result) == 3
+
+    def test_max_rows_passes_fewer_than_maximum(self, make_df: DataFrameFactory) -> None:
+        @df_in(max_rows=10)
+        def f(df: Any) -> Any:
+            return df
+
+        result = f(make_df({"a": [1, 2]}))
+        assert len(result) == 2
+
+
+class TestMinMaxRowsCombined:
+    def test_min_and_max_rows_passes_within_range(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=2, max_rows=5)
+        def f() -> Any:
+            return make_df({"a": [1, 2, 3]})
+
+        result = f()
+        assert len(result) == 3
+
+    def test_min_and_max_rows_rejects_below_min(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=3, max_rows=10)
+        def f() -> Any:
+            return make_df({"a": [1, 2]})
+
+        with pytest.raises(AssertionError, match=r"min_rows=3"):
+            f()
+
+    def test_min_and_max_rows_rejects_above_max(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=1, max_rows=3)
+        def f() -> Any:
+            return make_df({"a": [1, 2, 3, 4, 5]})
+
+        with pytest.raises(AssertionError, match=r"max_rows=3"):
+            f()

--- a/tests/test_shape_validation.py
+++ b/tests/test_shape_validation.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from daffy import df_out
+from daffy import df_in, df_out
 from tests.utils import DataFrameFactory
 
 
@@ -64,3 +64,53 @@ class TestMinRowsDfOut:
 
         with pytest.raises(AssertionError, match=r"return value"):
             f()
+
+
+class TestMinRowsDfIn:
+    def test_min_rows_rejects_too_few_rows(self, make_df: DataFrameFactory) -> None:
+        @df_in(min_rows=3)
+        def f(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match=r"has 2 rows but min_rows=3"):
+            f(make_df({"a": [1, 2]}))
+
+    def test_min_rows_passes_exact_count(self, make_df: DataFrameFactory) -> None:
+        @df_in(min_rows=3)
+        def f(df: Any) -> Any:
+            return df
+
+        result = f(make_df({"a": [1, 2, 3]}))
+        assert len(result) == 3
+
+    def test_min_rows_passes_more_than_minimum(self, make_df: DataFrameFactory) -> None:
+        @df_in(min_rows=2)
+        def f(df: Any) -> Any:
+            return df
+
+        result = f(make_df({"a": [1, 2, 3, 4]}))
+        assert len(result) == 4
+
+    def test_min_rows_rejects_empty_dataframe(self, make_df: DataFrameFactory) -> None:
+        @df_in(min_rows=1)
+        def f(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match=r"has 0 rows but min_rows=1"):
+            f(make_df({"a": []}))
+
+    def test_min_rows_error_includes_function_name(self, make_df: DataFrameFactory) -> None:
+        @df_in(min_rows=5)
+        def process_data(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match=r"function 'process_data'"):
+            process_data(make_df({"a": [1]}))
+
+    def test_min_rows_error_includes_parameter_name(self, make_df: DataFrameFactory) -> None:
+        @df_in(min_rows=5)
+        def f(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match=r"parameter 'df'"):
+            f(make_df({"a": [1]}))

--- a/tests/test_shape_validation.py
+++ b/tests/test_shape_validation.py
@@ -1,0 +1,66 @@
+"""Tests for DataFrame shape validation (min_rows, max_rows, exact_rows)."""
+
+from typing import Any
+
+import pytest
+
+from daffy import df_out
+from tests.utils import DataFrameFactory
+
+
+class TestMinRowsDfOut:
+    def test_min_rows_rejects_too_few_rows(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=3)
+        def f() -> Any:
+            return make_df({"a": [1, 2]})
+
+        with pytest.raises(AssertionError, match=r"has 2 rows but min_rows=3"):
+            f()
+
+    def test_min_rows_passes_exact_count(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=3)
+        def f() -> Any:
+            return make_df({"a": [1, 2, 3]})
+
+        result = f()
+        assert len(result) == 3
+
+    def test_min_rows_passes_more_than_minimum(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=2)
+        def f() -> Any:
+            return make_df({"a": [1, 2, 3, 4]})
+
+        result = f()
+        assert len(result) == 4
+
+    def test_min_rows_rejects_empty_dataframe(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=1)
+        def f() -> Any:
+            return make_df({"a": []})
+
+        with pytest.raises(AssertionError, match=r"has 0 rows but min_rows=1"):
+            f()
+
+    def test_min_rows_zero_allows_empty(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=0)
+        def f() -> Any:
+            return make_df({"a": []})
+
+        result = f()
+        assert len(result) == 0
+
+    def test_min_rows_error_includes_function_name(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=5)
+        def my_transform() -> Any:
+            return make_df({"a": [1]})
+
+        with pytest.raises(AssertionError, match=r"function 'my_transform'"):
+            my_transform()
+
+    def test_min_rows_error_indicates_return_value(self, make_df: DataFrameFactory) -> None:
+        @df_out(min_rows=5)
+        def f() -> Any:
+            return make_df({"a": [1]})
+
+        with pytest.raises(AssertionError, match=r"return value"):
+            f()


### PR DESCRIPTION
## Summary

- Add `min_rows`, `max_rows`, `exact_rows` parameters to `@df_in` and `@df_out` decorators
- Add `allow_empty` parameter and config option to control empty DataFrame handling
- Full lazy mode integration for shape validation errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DataFrame shape validation: enforce row-count constraints (min_rows, max_rows, exact_rows) on inputs and outputs; per-decorator overrides supported
  * Global allow_empty option to control empty-DataFrame handling (can be overridden per decorator)

* **Documentation**
  * Added Shape Validation guide with examples and error message descriptions
  * Updated configuration docs to describe allow_empty behavior and overrides

* **Tests**
  * Added comprehensive tests covering shape constraints, allow_empty, and lazy error collection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->