### PR TITLE
remove leftover pydocstyle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dev = [
     "coverage[toml]==7.13.1",
     "pytest-cov==7.0.0",
     "pre-commit==4.5.1",
-    "pydocstyle==6.3.0",
     "zensical==0.0.15",
 ]
 

--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,7 @@
         "vulture",
         "coverage",
         "pytest-cov",
-        "pre-commit",
-        "pydocstyle"
+        "pre-commit"
       ]
     },
     {


### PR DESCRIPTION
this was left over when we adopted Ruff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed pydocstyle from development dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->