### PR TITLE
Enable Renovate to update GitHub Action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
-  "ignorePresets": ["helpers:pinGitHubActionDigests"],
   "mode": "full",
   "prHourlyLimit": 10,
   "constraints": {


### PR DESCRIPTION
## Summary

- Remove `ignorePresets` for `helpers:pinGitHubActionDigests`
- Renovate will now update pinned commit hashes in GitHub Actions workflows