### PR TITLE
Add pandas 3.x support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.13"]
-        scenario: ["pandas-only", "polars-only", "both", "pandas-no-pydantic", "none"]
+        scenario: ["pandas-only", "polars-only", "both", "pandas-no-pydantic", "none", "pandas-2.x-only", "pandas-3.x-only"]
+        exclude:
+          # pandas 3.x requires Python 3.11+
+          - python-version: "3.10"
+            scenario: "pandas-3.x-only"
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -149,3 +153,15 @@ jobs:
         run: |
           WHEEL=$(ls dist/daffy-*.whl | head -n1)
           uv run --python ${{ matrix.python-version }} --no-project --with "$WHEEL" python scripts/test_isolated_deps.py none
+
+      - name: Test pandas 2.x only scenario
+        if: matrix.scenario == 'pandas-2.x-only'
+        run: |
+          WHEEL=$(ls dist/daffy-*.whl | head -n1)
+          uv run --python ${{ matrix.python-version }} --no-project --with "pandas>=1.5.1,<3.0.0" --with "$WHEEL" python scripts/test_isolated_deps.py pandas
+
+      - name: Test pandas 3.x only scenario
+        if: matrix.scenario == 'pandas-3.x-only'
+        run: |
+          WHEEL=$(ls dist/daffy-*.whl | head -n1)
+          uv run --python ${{ matrix.python-version }} --no-project --with "pandas>=3.0.0" --with "$WHEEL" python scripts/test_isolated_deps.py pandas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.6.0
+
+### Added
+
+- Support for pandas 3.x (requires Python 3.11+)
+
 ## 2.5.1
 
 ### Internal Improvements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "2.5.1"
+version = "2.6.0"
 description = "Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow."
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },
@@ -44,7 +44,7 @@ issues = "https://github.com/vertti/daffy/issues"
 test = [
     "pytest==9.0.2",
     "pytest-mock==3.15.1",
-    "pandas>=1.5.1,<3.0.0",
+    "pandas>=1.5.1",
     "polars>=1.7.0",
     "pydantic>=2.4.0",
     "modin[ray]>=0.30.0; python_version < '3.14'",


### PR DESCRIPTION
## Summary

- Remove the `<3.0.0` upper bound on pandas dependency
- Bump version to 2.6.0
- Add CI isolation tests for both pandas 2.x and 3.x

Daffy uses narwhals for all DataFrame operations, so it's unaffected by pandas 3.0 breaking changes (Copy-on-Write default, string dtype changes, removed APIs). Python 3.10 users will continue to get pandas 2.x since pandas 3.0 requires Python 3.11+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pandas 3.x (requires Python 3.11+)

* **Chores**
  * Released version 2.6.0
  * Relaxed pandas version constraints for broader compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->