### PR TITLE
Packaging: add pydantic extra and align install guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - Early import failure now triggers only when none of the supported DataFrame libraries are installed
 - Updated optional dependency tests and isolation docs/scripts to align with the expanded backend detection contract
 
+### Added
+
+- Declared `pydantic` optional dependency extra so `pip install 'daffy[pydantic]'` matches runtime install guidance
+
 ## 2.6.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,7 +118,11 @@ def clean_users(df):
 
 ### Row validation with Pydantic
 
-For complex, cross-field validation (requires `pydantic>=2.4.0`):
+For complex, cross-field validation:
+
+```bash
+pip install 'daffy[pydantic]'
+```
 
 ```python
 from pydantic import BaseModel, Field

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -429,7 +429,7 @@ In addition to column validation, Daffy supports row-level validation using Pyda
 First, install Pydantic if you haven't already:
 
 ```bash
-pip install 'pydantic>=2.4.0'
+pip install 'daffy[pydantic]'
 ```
 
 Define a Pydantic model describing your expected row structure:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ Daffy works with pandas, Polars, Modin, or PyArrow — whatever you already have
 For row validation with Pydantic:
 
 ```bash
-pip install 'pydantic>=2.4.0'
+pip install 'daffy[pydantic]'
 ```
 
 ## Your First Decorator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ dependencies = [
     "narwhals>=2.14.0",
 ]
 
+[project.optional-dependencies]
+pydantic = [
+    "pydantic>=2.4.0",
+]
+
 [project.urls]
 homepage = "https://github.com/vertti/daffy"
 repository = "https://github.com/vertti/daffy"
@@ -181,4 +186,3 @@ ignore = [
 python-version = "3.10"
 untyped-def-behavior = "check-and-infer-return-any"
 permissive-ignores = true
-

--- a/tests/test_pydantic_types.py
+++ b/tests/test_pydantic_types.py
@@ -1,5 +1,9 @@
 """Tests for optional Pydantic dependency support."""
 
+from pathlib import Path
+
+import tomli
+
 from daffy.pydantic_types import (
     HAS_PYDANTIC,
     BaseModel,
@@ -19,3 +23,13 @@ def test_require_pydantic() -> None:
 def test_pydantic_imports_available() -> None:
     assert BaseModel is not None
     assert ValidationError is not None
+
+
+def test_pydantic_extra_declared_in_pyproject() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        project = tomli.load(f)["project"]
+
+    optional_deps = project.get("optional-dependencies", {})
+    assert "pydantic" in optional_deps
+    assert "pydantic>=2.4.0" in optional_deps["pydantic"]

--- a/tests/test_pydantic_types.py
+++ b/tests/test_pydantic_types.py
@@ -1,8 +1,6 @@
 """Tests for optional Pydantic dependency support."""
 
-from pathlib import Path
-
-import tomli
+from importlib.metadata import PackageNotFoundError, metadata
 
 from daffy.pydantic_types import (
     HAS_PYDANTIC,
@@ -26,10 +24,10 @@ def test_pydantic_imports_available() -> None:
 
 
 def test_pydantic_extra_declared_in_pyproject() -> None:
-    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    with pyproject_path.open("rb") as f:
-        project = tomli.load(f)["project"]
+    try:
+        meta = metadata("daffy")
+    except PackageNotFoundError as exc:  # pragma: no cover
+        raise AssertionError("Package metadata for 'daffy' not found") from exc
 
-    optional_deps = project.get("optional-dependencies", {})
-    assert "pydantic" in optional_deps
-    assert "pydantic>=2.4.0" in optional_deps["pydantic"]
+    provides_extra = meta.get_all("Provides-Extra") or []
+    assert "pydantic" in provides_extra


### PR DESCRIPTION
## Summary
- add a real optional dependency extra for Pydantic in pyproject.toml
- align user-facing docs to the supported install path: pip install "daffy[pydantic]"
- add a test asserting the pydantic extra is declared in package metadata
- update changelog unreleased notes

## Validation
- pytest tests/test_pydantic_types.py -q
- pytest -q (full suite)
- ruff check on touched Python files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pydantic as an optional dependency extra; install with `pip install 'daffy[pydantic]'` to enable extended validation.

* **Documentation**
  * Updated installation instructions and validation guidance to reference the optional Pydantic extra instead of a pinned pydantic requirement.

* **Tests**
  * Added a test to verify the optional Pydantic extra is declared in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->