### PR TITLE
docs: sync API signatures and add docs contract tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to this project will be documented in this file.
 - Optional dependency detection now recognizes all advertised backends (Pandas, Polars, Modin, PyArrow)
 - Early import failure now triggers only when none of the supported DataFrame libraries are installed
 - Updated optional dependency tests and isolation docs/scripts to align with the expanded backend detection contract
+- Synced API docs and README examples with current `df_in`/`df_out`/`df_log` signatures and built-in check names
 
 ### Added
 
 - Declared `pydantic` optional dependency extra so `pip install 'daffy[pydantic]'` matches runtime install guidance
+- Added docs contract tests to detect signature/example drift in `README.md` and `docs/api.md`
 
 ## 2.6.0
 

--- a/README.md
+++ b/README.md
@@ -103,14 +103,17 @@ def process_orders(df):
 ```
 
 Available checks: `gt`, `ge`, `lt`, `le`, `between`, `eq`, `ne`, `isin`, `notnull`, `str_regex`
+Also supported: `notin`, `str_startswith`, `str_endswith`, `str_contains`, `str_length`
 
 ### Nullability and uniqueness
 
 ```python
 @df_in(
-    columns=["user_id", "email", "age"],
-    nullable={"email": False},  # email cannot be null
-    unique=["user_id"],         # user_id must be unique
+    columns={
+        "user_id": {"unique": True, "nullable": False},  # user_id must be unique and not null
+        "email": {"nullable": False},  # email cannot be null
+        "age": {"dtype": "int64"},
+    }
 )
 def clean_users(df):
     return df

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,18 +9,30 @@ Validates DataFrame parameters passed to a function.
     name: str | None = None,
     columns: list[str] | dict[str, str | dict] | None = None,
     strict: bool | None = None,
-    row_validator: type[BaseModel] | None = None
+    lazy: bool | None = None,
+    composite_unique: list[list[str]] | None = None,
+    row_validator: type[BaseModel] | None = None,
+    min_rows: int | None = None,
+    max_rows: int | None = None,
+    exact_rows: int | None = None,
+    allow_empty: bool | None = None
 )
 ```
 
 **Parameters:**
 
-| Parameter       | Type                        | Description                                                                                   |
-| --------------- | --------------------------- | --------------------------------------------------------------------------------------------- |
-| `name`          | `str` or `None`             | Name of the parameter to validate. If not specified, validates the first DataFrame parameter. |
-| `columns`       | `list` or `dict` or `None`  | Column specification. See [Column Specifications](#column-specifications).                    |
-| `strict`        | `bool` or `None`            | If `True`, raises error for unexpected columns. Defaults to project config or `False`.        |
-| `row_validator` | `type[BaseModel]` or `None` | Pydantic model for row-level validation.                                                      |
+| Parameter          | Type                        | Description                                                                                   |
+| ------------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
+| `name`             | `str` or `None`             | Name of the parameter to validate. If not specified, validates the first DataFrame parameter. |
+| `columns`          | `list` or `dict` or `None`  | Column specification. See [Column Specifications](#column-specifications).                    |
+| `strict`           | `bool` or `None`            | If `True`, raises error for unexpected columns. Defaults to project config or `False`.        |
+| `lazy`             | `bool` or `None`            | If `True`, collects all validation errors before raising. Defaults to project config or `False`. |
+| `composite_unique` | `list[list[str]]` or `None` | Column combinations that must be unique (for example `[['first_name', 'last_name']]`).       |
+| `row_validator`    | `type[BaseModel]` or `None` | Pydantic model for row-level validation.                                                      |
+| `min_rows`         | `int` or `None`             | Minimum number of rows required.                                                              |
+| `max_rows`         | `int` or `None`             | Maximum number of rows allowed.                                                               |
+| `exact_rows`       | `int` or `None`             | Exact number of rows required.                                                                |
+| `allow_empty`      | `bool` or `None`            | Whether empty DataFrames are allowed. Defaults to project config or `True`.                  |
 
 **Examples:**
 
@@ -40,6 +52,9 @@ Validates DataFrame parameters passed to a function.
 
 # Row validation
 @df_in(row_validator=OrderModel)
+
+# Shape/lazy controls
+@df_in(columns={"email": {"nullable": False}}, lazy=True, min_rows=1, allow_empty=False)
 ```
 
 ---
@@ -52,17 +67,29 @@ Validates the DataFrame returned by a function.
 @df_out(
     columns: list[str] | dict[str, str | dict] | None = None,
     strict: bool | None = None,
-    row_validator: type[BaseModel] | None = None
+    lazy: bool | None = None,
+    composite_unique: list[list[str]] | None = None,
+    row_validator: type[BaseModel] | None = None,
+    min_rows: int | None = None,
+    max_rows: int | None = None,
+    exact_rows: int | None = None,
+    allow_empty: bool | None = None
 )
 ```
 
 **Parameters:**
 
-| Parameter       | Type                        | Description                                                                            |
-| --------------- | --------------------------- | -------------------------------------------------------------------------------------- |
-| `columns`       | `list` or `dict` or `None`  | Column specification. See [Column Specifications](#column-specifications).             |
-| `strict`        | `bool` or `None`            | If `True`, raises error for unexpected columns. Defaults to project config or `False`. |
-| `row_validator` | `type[BaseModel]` or `None` | Pydantic model for row-level validation.                                               |
+| Parameter          | Type                        | Description                                                                            |
+| ------------------ | --------------------------- | -------------------------------------------------------------------------------------- |
+| `columns`          | `list` or `dict` or `None`  | Column specification. See [Column Specifications](#column-specifications).             |
+| `strict`           | `bool` or `None`            | If `True`, raises error for unexpected columns. Defaults to project config or `False`. |
+| `lazy`             | `bool` or `None`            | If `True`, collects all validation errors before raising. Defaults to project config or `False`. |
+| `composite_unique` | `list[list[str]]` or `None` | Column combinations that must be unique (for example `[['country', 'city']]`).        |
+| `row_validator`    | `type[BaseModel]` or `None` | Pydantic model for row-level validation.                                               |
+| `min_rows`         | `int` or `None`             | Minimum number of rows required.                                                       |
+| `max_rows`         | `int` or `None`             | Maximum number of rows allowed.                                                        |
+| `exact_rows`       | `int` or `None`             | Exact number of rows required.                                                         |
+| `allow_empty`      | `bool` or `None`            | Whether empty DataFrames are allowed. Defaults to project config or `True`.           |
 
 **Examples:**
 
@@ -72,6 +99,8 @@ Validates the DataFrame returned by a function.
 @df_out(columns={"score": "float64"}, strict=True)
 
 @df_out(row_validator=ResultModel)
+
+@df_out(min_rows=10, max_rows=100, lazy=True)
 ```
 
 ---
@@ -82,6 +111,7 @@ Logs DataFrame structure when entering and exiting a function.
 
 ```python
 @df_log(
+    level: int = logging.DEBUG,
     include_dtypes: bool = False
 )
 ```
@@ -90,12 +120,13 @@ Logs DataFrame structure when entering and exiting a function.
 
 | Parameter        | Type   | Description                                                        |
 | ---------------- | ------ | ------------------------------------------------------------------ |
+| `level`          | `int`  | Logging level for emitted messages. Default: `logging.DEBUG`.     |
 | `include_dtypes` | `bool` | If `True`, includes column dtypes in log output. Default: `False`. |
 
 **Examples:**
 
 ```python
-@df_log()
+@df_log(level=logging.INFO)
 def process(df):
     return df
 # Logs: Function process parameters contained a DataFrame: columns: ['a', 'b']
@@ -162,20 +193,27 @@ columns={"r/score_\\d+/": {"dtype": "float64", "checks": {"between": (0, 100)}}}
 
 ## Value Checks
 
-Available checks for the `checks` parameter:
+Available built-in checks for the `checks` parameter:
 
-| Check       | Argument   | Description                |
-| ----------- | ---------- | -------------------------- |
-| `gt`        | `number`   | Greater than               |
-| `ge`        | `number`   | Greater than or equal      |
-| `lt`        | `number`   | Less than                  |
-| `le`        | `number`   | Less than or equal         |
-| `eq`        | `value`    | Equal to                   |
-| `ne`        | `value`    | Not equal to               |
-| `between`   | `(lo, hi)` | Value in range (inclusive) |
-| `isin`      | `list`     | Value in set               |
-| `notnull`   | `True`     | No null values             |
-| `str_regex` | `pattern`  | String matches regex       |
+| Check              | Argument   | Description                |
+| ------------------ | ---------- | -------------------------- |
+| `gt`               | `number`   | Greater than               |
+| `ge`               | `number`   | Greater than or equal      |
+| `lt`               | `number`   | Less than                  |
+| `le`               | `number`   | Less than or equal         |
+| `eq`               | `value`    | Equal to                   |
+| `ne`               | `value`    | Not equal to               |
+| `between`          | `(lo, hi)` | Value in range (inclusive) |
+| `isin`             | `list`     | Value in set               |
+| `notin`            | `list`     | Value not in set           |
+| `notnull`          | `True`     | No null values             |
+| `str_regex`        | `pattern`  | String matches regex       |
+| `str_startswith`   | `str`      | String starts with prefix  |
+| `str_endswith`     | `str`      | String ends with suffix    |
+| `str_contains`     | `str`      | String contains substring  |
+| `str_length`       | `(lo, hi)` | String length in range     |
+
+Custom checks are also supported by passing a callable as the check value.
 
 **Examples:**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,18 +21,18 @@ Validates DataFrame parameters passed to a function.
 
 **Parameters:**
 
-| Parameter          | Type                        | Description                                                                                   |
-| ------------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
-| `name`             | `str` or `None`             | Name of the parameter to validate. If not specified, validates the first DataFrame parameter. |
-| `columns`          | `list` or `dict` or `None`  | Column specification. See [Column Specifications](#column-specifications).                    |
-| `strict`           | `bool` or `None`            | If `True`, raises error for unexpected columns. Defaults to project config or `False`.        |
+| Parameter          | Type                        | Description                                                                                      |
+| ------------------ | --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `name`             | `str` or `None`             | Name of the parameter to validate. If not specified, validates the first DataFrame parameter.    |
+| `columns`          | `list` or `dict` or `None`  | Column specification. See [Column Specifications](#column-specifications).                       |
+| `strict`           | `bool` or `None`            | If `True`, raises error for unexpected columns. Defaults to project config or `False`.           |
 | `lazy`             | `bool` or `None`            | If `True`, collects all validation errors before raising. Defaults to project config or `False`. |
-| `composite_unique` | `list[list[str]]` or `None` | Column combinations that must be unique (for example `[['first_name', 'last_name']]`).       |
-| `row_validator`    | `type[BaseModel]` or `None` | Pydantic model for row-level validation.                                                      |
-| `min_rows`         | `int` or `None`             | Minimum number of rows required.                                                              |
-| `max_rows`         | `int` or `None`             | Maximum number of rows allowed.                                                               |
-| `exact_rows`       | `int` or `None`             | Exact number of rows required.                                                                |
-| `allow_empty`      | `bool` or `None`            | Whether empty DataFrames are allowed. Defaults to project config or `True`.                  |
+| `composite_unique` | `list[list[str]]` or `None` | Column combinations that must be unique (for example `[['first_name', 'last_name']]`).           |
+| `row_validator`    | `type[BaseModel]` or `None` | Pydantic model for row-level validation.                                                         |
+| `min_rows`         | `int` or `None`             | Minimum number of rows required.                                                                 |
+| `max_rows`         | `int` or `None`             | Maximum number of rows allowed.                                                                  |
+| `exact_rows`       | `int` or `None`             | Exact number of rows required.                                                                   |
+| `allow_empty`      | `bool` or `None`            | Whether empty DataFrames are allowed. Defaults to project config or `True`.                      |
 
 **Examples:**
 
@@ -79,17 +79,17 @@ Validates the DataFrame returned by a function.
 
 **Parameters:**
 
-| Parameter          | Type                        | Description                                                                            |
-| ------------------ | --------------------------- | -------------------------------------------------------------------------------------- |
-| `columns`          | `list` or `dict` or `None`  | Column specification. See [Column Specifications](#column-specifications).             |
-| `strict`           | `bool` or `None`            | If `True`, raises error for unexpected columns. Defaults to project config or `False`. |
+| Parameter          | Type                        | Description                                                                                      |
+| ------------------ | --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `columns`          | `list` or `dict` or `None`  | Column specification. See [Column Specifications](#column-specifications).                       |
+| `strict`           | `bool` or `None`            | If `True`, raises error for unexpected columns. Defaults to project config or `False`.           |
 | `lazy`             | `bool` or `None`            | If `True`, collects all validation errors before raising. Defaults to project config or `False`. |
-| `composite_unique` | `list[list[str]]` or `None` | Column combinations that must be unique (for example `[['country', 'city']]`).        |
-| `row_validator`    | `type[BaseModel]` or `None` | Pydantic model for row-level validation.                                               |
-| `min_rows`         | `int` or `None`             | Minimum number of rows required.                                                       |
-| `max_rows`         | `int` or `None`             | Maximum number of rows allowed.                                                        |
-| `exact_rows`       | `int` or `None`             | Exact number of rows required.                                                         |
-| `allow_empty`      | `bool` or `None`            | Whether empty DataFrames are allowed. Defaults to project config or `True`.           |
+| `composite_unique` | `list[list[str]]` or `None` | Column combinations that must be unique (for example `[['country', 'city']]`).                   |
+| `row_validator`    | `type[BaseModel]` or `None` | Pydantic model for row-level validation.                                                         |
+| `min_rows`         | `int` or `None`             | Minimum number of rows required.                                                                 |
+| `max_rows`         | `int` or `None`             | Maximum number of rows allowed.                                                                  |
+| `exact_rows`       | `int` or `None`             | Exact number of rows required.                                                                   |
+| `allow_empty`      | `bool` or `None`            | Whether empty DataFrames are allowed. Defaults to project config or `True`.                      |
 
 **Examples:**
 
@@ -120,7 +120,7 @@ Logs DataFrame structure when entering and exiting a function.
 
 | Parameter        | Type   | Description                                                        |
 | ---------------- | ------ | ------------------------------------------------------------------ |
-| `level`          | `int`  | Logging level for emitted messages. Default: `logging.DEBUG`.     |
+| `level`          | `int`  | Logging level for emitted messages. Default: `logging.DEBUG`.      |
 | `include_dtypes` | `bool` | If `True`, includes column dtypes in log output. Default: `False`. |
 
 **Examples:**
@@ -195,23 +195,23 @@ columns={"r/score_\\d+/": {"dtype": "float64", "checks": {"between": (0, 100)}}}
 
 Available built-in checks for the `checks` parameter:
 
-| Check              | Argument   | Description                |
-| ------------------ | ---------- | -------------------------- |
-| `gt`               | `number`   | Greater than               |
-| `ge`               | `number`   | Greater than or equal      |
-| `lt`               | `number`   | Less than                  |
-| `le`               | `number`   | Less than or equal         |
-| `eq`               | `value`    | Equal to                   |
-| `ne`               | `value`    | Not equal to               |
-| `between`          | `(lo, hi)` | Value in range (inclusive) |
-| `isin`             | `list`     | Value in set               |
-| `notin`            | `list`     | Value not in set           |
-| `notnull`          | `True`     | No null values             |
-| `str_regex`        | `pattern`  | String matches regex       |
-| `str_startswith`   | `str`      | String starts with prefix  |
-| `str_endswith`     | `str`      | String ends with suffix    |
-| `str_contains`     | `str`      | String contains substring  |
-| `str_length`       | `(lo, hi)` | String length in range     |
+| Check            | Argument   | Description                |
+| ---------------- | ---------- | -------------------------- |
+| `gt`             | `number`   | Greater than               |
+| `ge`             | `number`   | Greater than or equal      |
+| `lt`             | `number`   | Less than                  |
+| `le`             | `number`   | Less than or equal         |
+| `eq`             | `value`    | Equal to                   |
+| `ne`             | `value`    | Not equal to               |
+| `between`        | `(lo, hi)` | Value in range (inclusive) |
+| `isin`           | `list`     | Value in set               |
+| `notin`          | `list`     | Value not in set           |
+| `notnull`        | `True`     | No null values             |
+| `str_regex`      | `pattern`  | String matches regex       |
+| `str_startswith` | `str`      | String starts with prefix  |
+| `str_endswith`   | `str`      | String ends with suffix    |
+| `str_contains`   | `str`      | String contains substring  |
+| `str_length`     | `(lo, hi)` | String length in range     |
 
 Custom checks are also supported by passing a callable as the check value.
 

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -1,0 +1,51 @@
+"""Documentation contract tests for public API examples."""
+
+from __future__ import annotations
+
+from inspect import signature
+from pathlib import Path
+from typing import get_args
+
+from daffy.checks import CheckName
+from daffy.decorators import df_in, df_log, df_out
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+API_DOC = (ROOT_DIR / "docs" / "api.md").read_text(encoding="utf-8")
+README_DOC = (ROOT_DIR / "README.md").read_text(encoding="utf-8")
+
+
+def _section(text: str, start_heading: str, end_heading: str | None = None) -> str:
+    start_index = text.index(start_heading)
+    if end_heading is None:
+        return text[start_index:]
+    end_index = text.index(end_heading, start_index)
+    return text[start_index:end_index]
+
+
+def test_api_reference_df_in_parameters_match_signature() -> None:
+    section = _section(API_DOC, "## @df_in", "## @df_out")
+    for parameter_name in signature(df_in).parameters:
+        assert f"`{parameter_name}`" in section
+
+
+def test_api_reference_df_out_parameters_match_signature() -> None:
+    section = _section(API_DOC, "## @df_out", "## @df_log")
+    for parameter_name in signature(df_out).parameters:
+        assert f"`{parameter_name}`" in section
+
+
+def test_api_reference_df_log_parameters_match_signature() -> None:
+    section = _section(API_DOC, "## @df_log", "## Column Specifications")
+    for parameter_name in signature(df_log).parameters:
+        assert f"`{parameter_name}`" in section
+
+
+def test_api_reference_lists_all_builtin_checks() -> None:
+    section = _section(API_DOC, "## Value Checks", "## Configuration")
+    for check_name in get_args(CheckName):
+        assert f"`{check_name}`" in section
+
+
+def test_readme_examples_do_not_use_removed_top_level_nullable_or_unique_args() -> None:
+    assert "nullable={" not in README_DOC
+    assert "unique=[" not in README_DOC


### PR DESCRIPTION
Summary:
- Sync docs/api.md signatures and parameter tables with current df_in, df_out, and df_log decorator APIs
- Fix stale README example that used removed top-level nullable/unique kwargs; show correct rich column spec format
- Document all built-in check names in API docs
- Add tests/test_docs_contract.py to enforce docs/runtime alignment for signatures and check names
- Update changelog for docs sync and docs-contract tests

Verification:
- UV_CACHE_DIR=/tmp/uv-cache mise x -- uv run ruff check tests/test_docs_contract.py
- UV_CACHE_DIR=/tmp/uv-cache mise x -- uv run ruff format --check tests/test_docs_contract.py
- UV_CACHE_DIR=/tmp/uv-cache mise x -- uv run pytest tests/test_docs_contract.py tests/test_type_compatibility.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation parameters to decorators: lazy error aggregation, composite uniqueness constraints, row count controls (min/max/exact), and empty DataFrame handling.
  * Added new string checks: notin, str_startswith, str_endswith, str_contains, str_length.
  * Added logging level control to logging decorator.

* **Documentation**
  * Updated API documentation and README with new parameter descriptions and examples.

* **Tests**
  * Added documentation consistency tests to prevent signature and example drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->