### PR TITLE
config: support parent pyproject discovery with cwd-aware cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Early import failure now triggers only when none of the supported DataFrame libraries are installed
 - Updated optional dependency tests and isolation docs/scripts to align with the expanded backend detection contract
 - Synced API docs and README examples with current `df_in`/`df_out`/`df_log` signatures and built-in check names
+- Config discovery now searches `pyproject.toml` from the current directory up through parent directories
+- Configuration caching is now keyed by current working directory for deterministic behavior across cwd changes
 
 ### Added
 

--- a/daffy/config.py
+++ b/daffy/config.py
@@ -64,11 +64,11 @@ _DEFAULTS: dict[str, Any] = {
 }
 
 
-def load_config() -> dict[str, Any]:
+def load_config(cwd: Path | None = None) -> dict[str, Any]:
     """Load daffy configuration from pyproject.toml."""
     config = dict(_DEFAULTS)
 
-    config_path = find_config_file()
+    config_path = find_config_file(cwd)
     if not config_path:
         return config
 
@@ -89,24 +89,34 @@ def load_config() -> dict[str, Any]:
     return config
 
 
-def find_config_file() -> str | None:
-    """Find pyproject.toml in the current working directory."""
-    path = Path.cwd() / "pyproject.toml"
-    return str(path) if path.is_file() else None
+def find_config_file(cwd: Path | None = None) -> str | None:
+    """Find pyproject.toml in the current working directory or any parent directory."""
+    current_dir = cwd.resolve() if cwd is not None else Path.cwd().resolve()
+    for parent in [current_dir, *current_dir.parents]:
+        path = parent / "pyproject.toml"
+        if path.is_file():
+            return str(path)
+    return None
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=128)
+def _get_config_for_cwd(cwd: str) -> MappingProxyType[str, Any]:
+    """Load and cache configuration for a specific current working directory."""
+    return MappingProxyType(load_config(Path(cwd)))
+
+
 def get_config() -> MappingProxyType[str, Any]:
-    """Get the daffy configuration, cached after first load.
+    """Get the daffy configuration, cached by current working directory.
 
     Returns an immutable view of the configuration to prevent accidental modification.
     """
-    return MappingProxyType(load_config())
+    cwd = str(Path.cwd().resolve())
+    return _get_config_for_cwd(cwd)
 
 
 def clear_config_cache() -> None:
     """Clear the configuration cache. Primarily for testing."""
-    get_config.cache_clear()
+    _get_config_for_cwd.cache_clear()
 
 
 def _get_bool_config(param: bool | None, key: str) -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,6 +79,40 @@ def test_find_config_file_returns_none_when_no_pyproject_exists() -> None:
         assert result is None
 
 
+def test_find_config_file_searches_parent_directories() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir) / "project"
+        nested_dir = project_dir / "src" / "module"
+        nested_dir.mkdir(parents=True)
+        pyproject_path = project_dir / "pyproject.toml"
+        pyproject_path.write_text("[tool.daffy]\nstrict = true\n", encoding="utf-8")
+
+        with patch("daffy.config.Path.cwd", return_value=nested_dir):
+            from daffy.config import find_config_file
+
+            result = find_config_file()
+            assert result == str(pyproject_path.resolve())
+
+
+def test_find_config_file_prefers_nearest_parent() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir) / "project"
+        package_dir = project_dir / "pkg"
+        nested_dir = package_dir / "tests"
+        nested_dir.mkdir(parents=True)
+
+        root_pyproject = project_dir / "pyproject.toml"
+        package_pyproject = package_dir / "pyproject.toml"
+        root_pyproject.write_text("[tool.daffy]\nstrict = false\n", encoding="utf-8")
+        package_pyproject.write_text("[tool.daffy]\nstrict = true\n", encoding="utf-8")
+
+        with patch("daffy.config.Path.cwd", return_value=nested_dir):
+            from daffy.config import find_config_file
+
+            result = find_config_file()
+            assert result == str(package_pyproject.resolve())
+
+
 def test_load_config_without_strict_setting() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
@@ -258,3 +292,43 @@ row_validation_max_errors = 0
                 load_config()
             assert "row_validation_max_errors" in str(exc_info.value)
             assert ">= 1" in str(exc_info.value)
+
+
+def test_get_config_cache_isolated_by_cwd() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir) / "project"
+        nested_dir = project_dir / "src"
+        external_dir = Path(tmpdir) / "external"
+        nested_dir.mkdir(parents=True)
+        external_dir.mkdir(parents=True)
+
+        (project_dir / "pyproject.toml").write_text("[tool.daffy]\nstrict = true\n", encoding="utf-8")
+
+        clear_config_cache()
+        with patch("daffy.config.Path.cwd", return_value=nested_dir):
+            nested_config = get_config()
+            assert nested_config["strict"] is True
+
+        with patch("daffy.config.Path.cwd", return_value=external_dir):
+            external_config = get_config()
+            assert external_config["strict"] is False
+
+
+def test_get_config_uses_cache_for_same_cwd() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pyproject_path = Path(tmpdir) / "pyproject.toml"
+        pyproject_path.write_text("[tool.daffy]\nstrict = true\n", encoding="utf-8")
+
+        from daffy.config import load_config
+
+        clear_config_cache()
+        with (
+            patch("daffy.config.Path.cwd", return_value=Path(tmpdir)),
+            patch("daffy.config.load_config", wraps=load_config) as mocked_load_config,
+        ):
+            first = get_config()
+            second = get_config()
+
+            assert first["strict"] is True
+            assert second["strict"] is True
+            assert mocked_load_config.call_count == 1


### PR DESCRIPTION
Summary:
- make config discovery search pyproject.toml from current directory up through parent directories
- key configuration caching by current working directory to avoid stale config when cwd changes in-process
- keep returned config immutable via MappingProxyType
- add tests for parent lookup, nearest-parent precedence, cache isolation across cwd values, and cache reuse within a single cwd
- update changelog with config discovery/caching behavior changes

Verification:
- mise x -- uv run pytest tests/test_config.py -q
- mise x -- uv run ruff check daffy/config.py tests/test_config.py
- mise x -- uv run ruff format --check daffy/config.py tests/test_config.py
- mise x -- uv run pyrefly check .
- mise x -- uv run vulture daffy --min-confidence 100
- XDG_CACHE_HOME=/tmp mise x -- dprint check
- mise x -- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration discovery now searches parent directories for `pyproject.toml` files, making it easier to find configurations in nested projects.
  * Configuration caching is now isolated by working directory for deterministic behavior across different directory contexts.

* **Tests**
  * Added comprehensive tests validating configuration discovery with parent directory traversal and per-directory cache isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->