### PR TITLE
df_in: harden unnamed parameter selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Synced API docs and README examples with current `df_in`/`df_out`/`df_log` signatures and built-in check names
 - Config discovery now searches `pyproject.toml` from the current directory up through parent directories
 - Configuration caching is now keyed by current working directory for deterministic behavior across cwd changes
+- Unnamed `df_in` now selects the first DataFrame-like argument instead of always taking the first positional argument
 
 ### Added
 

--- a/daffy/utils.py
+++ b/daffy/utils.py
@@ -36,7 +36,9 @@ def get_parameter(func: Callable[..., Any], name: str | None = None, *args: Any,
 
     Args:
         func: The function whose parameters to inspect
-        name: Name of the parameter to extract. If None, returns first positional arg or kwarg.
+        name: Name of the parameter to extract. If None, the function first attempts to
+            find and return a DataFrame-like argument; if no DataFrame-like argument is
+            found, it falls back to returning the first positional arg or kwarg.
         *args: Positional arguments passed to the function
         **kwargs: Keyword arguments passed to the function
 
@@ -75,6 +77,24 @@ def get_parameter(func: Callable[..., Any], name: str | None = None, *args: Any,
 
 
 def get_parameter_name(func: Callable[..., Any], name: str | None = None, *args: Any, **kwargs: Any) -> str | None:
+    """Resolve the effective parameter name used for validation.
+
+    Resolution order:
+    1. Return the explicit ``name`` argument when provided.
+    2. Find the first DataFrame-like argument via ``_find_first_dataframe_argument``.
+    3. Fall back to the first positional parameter name if positional args were provided.
+    4. Fall back to the first keyword argument name.
+
+    Args:
+        func: The function whose parameters to inspect.
+        name: Explicit parameter name to use, or ``None`` for automatic resolution.
+        *args: Positional arguments passed to the function.
+        **kwargs: Keyword arguments passed to the function.
+
+    Returns:
+        The resolved parameter name, or ``None`` when no name can be determined.
+
+    """
     if name:
         return name
 
@@ -91,9 +111,10 @@ def get_parameter_name(func: Callable[..., Any], name: str | None = None, *args:
 
 def _find_first_dataframe_argument(func: Callable[..., Any], *args: Any, **kwargs: Any) -> tuple[Any, str] | None:
     """Find the first DataFrame-like argument using function signature order."""
-    bound_args = inspect.signature(func).bind_partial(*args, **kwargs)
+    sig = inspect.signature(func)
+    bound_args = sig.bind_partial(*args, **kwargs)
 
-    for param_name, param in inspect.signature(func).parameters.items():
+    for param_name, param in sig.parameters.items():
         if param_name not in bound_args.arguments:
             continue
 

--- a/daffy/utils.py
+++ b/daffy/utils.py
@@ -48,7 +48,11 @@ def get_parameter(func: Callable[..., Any], name: str | None = None, *args: Any,
 
     """
     if not name:
-        # Return first arg/kwarg or None - let downstream code handle validation
+        first_dataframe_arg = _find_first_dataframe_argument(func, *args, **kwargs)
+        if first_dataframe_arg is not None:
+            return first_dataframe_arg[0]
+
+        # Keep existing fallback behavior when no DataFrame-like argument is present.
         return args[0] if args else next(iter(kwargs.values()), None)
 
     if name in kwargs:
@@ -74,11 +78,43 @@ def get_parameter_name(func: Callable[..., Any], name: str | None = None, *args:
     if name:
         return name
 
+    first_dataframe_arg = _find_first_dataframe_argument(func, *args, **kwargs)
+    if first_dataframe_arg is not None:
+        return first_dataframe_arg[1]
+
     if args:
         func_params_in_order = list(inspect.signature(func).parameters.keys())
         return func_params_in_order[0]
 
     return next(iter(kwargs.keys()), None)
+
+
+def _find_first_dataframe_argument(func: Callable[..., Any], *args: Any, **kwargs: Any) -> tuple[Any, str] | None:
+    """Find the first DataFrame-like argument using function signature order."""
+    bound_args = inspect.signature(func).bind_partial(*args, **kwargs)
+
+    for param_name, param in inspect.signature(func).parameters.items():
+        if param_name not in bound_args.arguments:
+            continue
+
+        value = bound_args.arguments[param_name]
+
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
+            for item in value:
+                if is_supported_dataframe(item):
+                    return item, param_name
+            continue
+
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            for kwarg_name, kwarg_value in value.items():
+                if is_supported_dataframe(kwarg_value):
+                    return kwarg_value, kwarg_name
+            continue
+
+        if is_supported_dataframe(value):
+            return value, param_name
+
+    return None
 
 
 def describe_dataframe(df: Any, include_dtypes: bool = False) -> str:

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -69,7 +69,7 @@ def test_df_in_unnamed_selects_first_dataframe_like_parameter(df: IntoDataFrame)
         return table
 
     result = test_fn("context", df, 3)
-    assert result is not None
+    assert result is df
 
 
 @pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
@@ -79,7 +79,7 @@ def test_df_in_unnamed_selects_dataframe_like_parameter_with_kwargs(df: IntoData
         return table
 
     result = test_fn(metadata="context", table=df)
-    assert result is not None
+    assert result is df
 
 
 @pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -63,6 +63,26 @@ def test_dfin_with_no_inputs() -> None:
 
 
 @pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
+def test_df_in_unnamed_selects_first_dataframe_like_parameter(df: IntoDataFrame) -> None:
+    @df_in(columns=["Brand", "Price"])
+    def test_fn(metadata: str, table: IntoDataFrame, retries: int) -> IntoDataFrame:
+        return table
+
+    result = test_fn("context", df, 3)
+    assert result is not None
+
+
+@pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
+def test_df_in_unnamed_selects_dataframe_like_parameter_with_kwargs(df: IntoDataFrame) -> None:
+    @df_in(columns=["Brand", "Price"])
+    def test_fn(metadata: str, table: IntoDataFrame) -> IntoDataFrame:
+        return table
+
+    result = test_fn(metadata="context", table=df)
+    assert result is not None
+
+
+@pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
 def test_correct_named_input_with_columns(df: IntoDataFrame) -> None:
     @df_in(name="_df", columns=["Brand", "Price"])
     def test_fn(my_input: Any, _df: IntoDataFrame) -> IntoDataFrame:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
 """Tests for utility functions."""
 
+import pandas as pd
 import pytest
 
-from daffy.utils import get_parameter
+from daffy.utils import get_parameter, get_parameter_name
 
 
 def test_get_parameter_name_not_in_signature() -> None:
@@ -19,3 +20,29 @@ def test_get_parameter_not_provided() -> None:
 
     with pytest.raises(ValueError, match="not found in function arguments"):
         get_parameter(func, "c", 1, 2)
+
+
+def test_get_parameter_unnamed_selects_first_dataframe_like_argument() -> None:
+    def func(meta: str, df: pd.DataFrame, count: int) -> None:
+        pass
+
+    dataframe = pd.DataFrame({"a": [1, 2]})
+    result = get_parameter(func, None, "metadata", dataframe, 5)
+    assert result is dataframe
+
+
+def test_get_parameter_name_unnamed_selects_dataframe_parameter_name() -> None:
+    def func(meta: str, df: pd.DataFrame, count: int) -> None:
+        pass
+
+    dataframe = pd.DataFrame({"a": [1, 2]})
+    result = get_parameter_name(func, None, "metadata", dataframe, 5)
+    assert result == "df"
+
+
+def test_get_parameter_unnamed_falls_back_when_no_dataframe_like_argument() -> None:
+    def func(meta: str, count: int) -> None:
+        pass
+
+    result = get_parameter(func, None, "metadata", 5)
+    assert result == "metadata"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for utility functions."""
 
+from typing import Any
+
 import pandas as pd
 import pytest
 
@@ -46,3 +48,50 @@ def test_get_parameter_unnamed_falls_back_when_no_dataframe_like_argument() -> N
 
     result = get_parameter(func, None, "metadata", 5)
     assert result == "metadata"
+
+
+def test_get_parameter_unnamed_selects_dataframe_in_varargs() -> None:
+    def func(meta: str, *items: Any) -> None:
+        pass
+
+    dataframe = pd.DataFrame({"a": [1, 2]})
+    result = get_parameter(func, None, "metadata", 1, dataframe, 2)
+    assert result is dataframe
+
+    parameter_name = get_parameter_name(func, None, "metadata", 1, dataframe, 2)
+    assert parameter_name == "items"
+
+
+def test_get_parameter_unnamed_skips_non_dataframe_varargs_then_uses_later_param() -> None:
+    def func(meta: str, *items: Any, table: pd.DataFrame | None = None) -> None:
+        pass
+
+    dataframe = pd.DataFrame({"a": [1, 2]})
+    result = get_parameter(func, None, "metadata", 1, 2, table=dataframe)
+    assert result is dataframe
+
+    parameter_name = get_parameter_name(func, None, "metadata", 1, 2, table=dataframe)
+    assert parameter_name == "table"
+
+
+def test_get_parameter_unnamed_selects_dataframe_in_varkwargs() -> None:
+    def func(meta: str, **options: Any) -> None:
+        pass
+
+    dataframe = pd.DataFrame({"a": [1, 2]})
+    result = get_parameter(func, None, "metadata", payload=dataframe)
+    assert result is dataframe
+
+    parameter_name = get_parameter_name(func, None, "metadata", payload=dataframe)
+    assert parameter_name == "payload"
+
+
+def test_get_parameter_unnamed_falls_back_when_varkwargs_have_no_dataframe() -> None:
+    def func(meta: str, **options: Any) -> None:
+        pass
+
+    result = get_parameter(func, None, "metadata", retries=3, verbose=True)
+    assert result == "metadata"
+
+    parameter_name = get_parameter_name(func, None, "metadata", retries=3, verbose=True)
+    assert parameter_name == "meta"


### PR DESCRIPTION
Summary:
- make unnamed df_in parameter resolution pick the first DataFrame-like argument instead of always taking the first positional argument
- keep explicit name=... selection unchanged and highest priority
- align unnamed parameter-name reporting with the selected DataFrame-like argument for clearer errors
- add regression tests in tests/test_utils.py and tests/test_df_in.py for mixed argument lists and kwargs
- update changelog

Verification:
- mise x -- uv run pytest tests/test_utils.py tests/test_df_in.py -q
- mise x -- uv run ruff check daffy/utils.py tests/test_utils.py tests/test_df_in.py
- mise x -- uv run ruff format --check daffy/utils.py tests/test_utils.py tests/test_df_in.py
- mise x -- uv run pyrefly check .
- mise x -- uv run vulture daffy --min-confidence 100
- XDG_CACHE_HOME=/tmp mise x -- dprint check
- mise x -- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * When using `df_in()` without specifying a parameter name, the system now intelligently selects the first DataFrame-like argument, providing more intuitive default behavior across different function signatures.

* **Tests**
  * Added test cases to verify correct parameter selection with various argument configurations and DataFrame types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->