### PR TITLE
validation: add opt-in strict column spec mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Config discovery now searches `pyproject.toml` from the current directory up through parent directories
 - Configuration caching is now keyed by current working directory for deterministic behavior across cwd changes
 - Unnamed `df_in` now selects the first DataFrame-like argument instead of always taking the first positional argument
+- Added opt-in strict column spec validation via `[tool.daffy] strict_specs = true` for invalid column keys/types
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ All notable changes to this project will be documented in this file.
 - Config discovery now searches `pyproject.toml` from the current directory up through parent directories
 - Configuration caching is now keyed by current working directory for deterministic behavior across cwd changes
 - Unnamed `df_in` now selects the first DataFrame-like argument instead of always taking the first positional argument
-- Added opt-in strict column spec validation via `[tool.daffy] strict_specs = true` for invalid column keys/types
 
 ### Added
 
 - Declared `pydantic` optional dependency extra so `pip install 'daffy[pydantic]'` matches runtime install guidance
 - Added docs contract tests to detect signature/example drift in `README.md` and `docs/api.md`
+- Added opt-in strict column spec validation via `[tool.daffy] strict_specs = true` for invalid column keys/types
 
 ## 2.6.0
 

--- a/daffy/config.py
+++ b/daffy/config.py
@@ -12,6 +12,7 @@ import tomli
 # Configuration keys
 _KEY_STRICT = "strict"
 _KEY_LAZY = "lazy"
+_KEY_STRICT_SPECS = "strict_specs"
 _KEY_ROW_VALIDATION_MAX_ERRORS = "row_validation_max_errors"
 _KEY_CHECKS_MAX_SAMPLES = "checks_max_samples"
 _KEY_ALLOW_EMPTY = "allow_empty"
@@ -19,6 +20,7 @@ _KEY_ALLOW_EMPTY = "allow_empty"
 # Default values
 _DEFAULT_STRICT = False
 _DEFAULT_LAZY = False
+_DEFAULT_STRICT_SPECS = False
 _DEFAULT_MAX_ERRORS = 5
 _DEFAULT_CHECKS_MAX_SAMPLES = 5
 _DEFAULT_ALLOW_EMPTY = True
@@ -52,12 +54,13 @@ def _validate_int_config(daffy_config: dict[str, Any], key: str, min_value: int 
     return value
 
 
-_BOOL_KEYS = [_KEY_STRICT, _KEY_LAZY, _KEY_ALLOW_EMPTY]
+_BOOL_KEYS = [_KEY_STRICT, _KEY_LAZY, _KEY_STRICT_SPECS, _KEY_ALLOW_EMPTY]
 _INT_KEYS = [_KEY_ROW_VALIDATION_MAX_ERRORS, _KEY_CHECKS_MAX_SAMPLES]
 
 _DEFAULTS: dict[str, Any] = {
     _KEY_STRICT: _DEFAULT_STRICT,
     _KEY_LAZY: _DEFAULT_LAZY,
+    _KEY_STRICT_SPECS: _DEFAULT_STRICT_SPECS,
     _KEY_ROW_VALIDATION_MAX_ERRORS: _DEFAULT_MAX_ERRORS,
     _KEY_CHECKS_MAX_SAMPLES: _DEFAULT_CHECKS_MAX_SAMPLES,
     _KEY_ALLOW_EMPTY: _DEFAULT_ALLOW_EMPTY,
@@ -160,6 +163,21 @@ def get_lazy(lazy_param: bool | None = None) -> bool:
 
     """
     return _get_bool_config(lazy_param, _KEY_LAZY)
+
+
+def get_strict_specs(strict_specs_param: bool | None = None) -> bool:
+    """Get strict_specs setting, with explicit parameter taking precedence over configuration.
+
+    When strict_specs=True, invalid column spec keys/types raise errors instead of being ignored.
+
+    Args:
+        strict_specs_param: Explicitly provided strict_specs value, or None to use config
+
+    Returns:
+        bool: The effective strict_specs setting
+
+    """
+    return _get_bool_config(strict_specs_param, _KEY_STRICT_SPECS)
 
 
 def get_row_validation_max_errors() -> int:

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -139,6 +139,10 @@ def df_out(
         allow_empty (bool, optional): Whether empty DataFrames (0 rows) are allowed.
             If None, uses the value from [tool.daffy] allow_empty setting in pyproject.toml.
 
+    Note:
+        When ``[tool.daffy] strict_specs = true`` is set in pyproject.toml, invalid column
+        keys or spec types raise ``TypeError`` instead of being silently ignored.
+
     Returns:
         Callable: Decorated function with preserved DataFrame return type
 
@@ -242,6 +246,10 @@ def df_in(
         exact_rows (int, optional): Exact number of rows required. Defaults to None (no constraint).
         allow_empty (bool, optional): Whether empty DataFrames (0 rows) are allowed.
             If None, uses the value from [tool.daffy] allow_empty setting in pyproject.toml.
+
+    Note:
+        When ``[tool.daffy] strict_specs = true`` is set in pyproject.toml, invalid column
+        keys or spec types raise ``TypeError`` instead of being silently ignored.
 
     Returns:
         Callable: Decorated function with preserved return type

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from daffy.dataframe_types import IntoDataFrameT
     from daffy.validation import ColumnsDef
 
-from daffy.config import get_allow_empty, get_lazy, get_strict
+from daffy.config import get_allow_empty, get_lazy, get_strict, get_strict_specs
 from daffy.utils import (
     assert_is_dataframe,
     get_parameter,
@@ -91,6 +91,7 @@ def _run_validations(
     pipeline = build_validation_pipeline(
         columns=columns,
         strict=get_strict(strict),
+        strict_specs=get_strict_specs(),
         lazy=get_lazy(lazy),
         composite_unique=composite_unique,
         row_validator=row_validator,

--- a/daffy/validators/builder.py
+++ b/daffy/validators/builder.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from daffy.config import get_strict_specs
 from daffy.patterns import compile_regex_pattern, is_regex_string, match_column_with_regex
 
 if TYPE_CHECKING:
@@ -56,6 +55,7 @@ def _expand_specs(specs: dict[str, Any] | list[str], resolved: dict[str, list[st
 def build_validation_pipeline(  # noqa: C901
     columns: Sequence[Any] | dict[Any, Any] | None,
     strict: bool,
+    strict_specs: bool,
     lazy: bool,
     composite_unique: list[list[str]] | None,
     row_validator: type | None,
@@ -75,7 +75,7 @@ def build_validation_pipeline(  # noqa: C901
         )
 
     if columns:
-        spec = parse_column_spec(columns, strict_specs=get_strict_specs())
+        spec = parse_column_spec(columns, strict_specs=strict_specs)
 
         missing_required, resolved_required = _resolve_columns(spec.required_columns, df_columns)
         if missing_required:

--- a/daffy/validators/builder.py
+++ b/daffy/validators/builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from daffy.config import get_strict_specs
 from daffy.patterns import compile_regex_pattern, is_regex_string, match_column_with_regex
 
 if TYPE_CHECKING:
@@ -74,7 +75,7 @@ def build_validation_pipeline(  # noqa: C901
         )
 
     if columns:
-        spec = parse_column_spec(columns)
+        spec = parse_column_spec(columns, strict_specs=get_strict_specs())
 
         missing_required, resolved_required = _resolve_columns(spec.required_columns, df_columns)
         if missing_required:

--- a/daffy/validators/spec_parser.py
+++ b/daffy/validators/spec_parser.py
@@ -59,19 +59,30 @@ def _parse_dict_constraints(col_name: str, constraints: dict[str, Any], result: 
         result.checks_by_column[col_name] = constraints["checks"]
 
 
-def _parse_list_spec(columns: Sequence[Any], result: ParsedColumnSpec) -> None:
+def _parse_list_spec(columns: Sequence[Any], result: ParsedColumnSpec, strict_specs: bool) -> None:
     """Parse a list column specification."""
-    for c in columns:
+    for index, c in enumerate(columns):
         col_name = _get_col_name(c)
-        if col_name is not None:
-            result.required_columns.append(col_name)
+        if col_name is None:
+            if strict_specs:
+                raise TypeError(
+                    "Invalid column spec at index "
+                    f"{index}: expected str or regex column pattern, got {type(c).__name__}"
+                )
+            continue
+        result.required_columns.append(col_name)
 
 
-def _parse_dict_spec(columns: dict[Any, Any], result: ParsedColumnSpec) -> None:
+def _parse_dict_spec(columns: dict[Any, Any], result: ParsedColumnSpec, strict_specs: bool) -> None:
     """Parse a dict column specification."""
-    for col_spec, value in columns.items():
+    for index, (col_spec, value) in enumerate(columns.items()):
         col_name = _get_col_name(col_spec)
         if col_name is None:
+            if strict_specs:
+                raise TypeError(
+                    "Invalid column key at index "
+                    f"{index}: expected str or regex column pattern, got {type(col_spec).__name__}"
+                )
             continue  # Skip invalid column types
 
         if isinstance(value, dict):
@@ -81,7 +92,7 @@ def _parse_dict_spec(columns: dict[Any, Any], result: ParsedColumnSpec) -> None:
             result.dtype_constraints[col_name] = value
 
 
-def parse_column_spec(columns: Sequence[Any] | dict[Any, Any] | None) -> ParsedColumnSpec:
+def parse_column_spec(columns: Sequence[Any] | dict[Any, Any] | None, strict_specs: bool = False) -> ParsedColumnSpec:
     """Parse user-provided column specification into validator-ready format.
 
     Handles:
@@ -90,7 +101,8 @@ def parse_column_spec(columns: Sequence[Any] | dict[Any, Any] | None) -> ParsedC
     - Dict with dtype: {"col1": "int64"} → required + dtype check
     - Dict with constraints: {"col1": {"dtype": ..., "nullable": False, "required": False, ...}}
 
-    Invalid column types (like integers) are silently ignored for backwards compatibility.
+    Invalid column types (like integers) are silently ignored for backwards compatibility
+    unless strict_specs=True.
     """
     result = ParsedColumnSpec()
 
@@ -98,11 +110,11 @@ def parse_column_spec(columns: Sequence[Any] | dict[Any, Any] | None) -> ParsedC
         return result
 
     if isinstance(columns, dict):
-        _parse_dict_spec(columns, result)
+        _parse_dict_spec(columns, result, strict_specs)
     elif isinstance(columns, str):
         # Treat a single string as a single column name, not a character sequence
-        _parse_list_spec([columns], result)
+        _parse_list_spec([columns], result, strict_specs)
     else:
-        _parse_list_spec(columns, result)
+        _parse_list_spec(columns, result, strict_specs)
 
     return result

--- a/daffy/validators/spec_parser.py
+++ b/daffy/validators/spec_parser.py
@@ -102,7 +102,8 @@ def parse_column_spec(columns: Sequence[Any] | dict[Any, Any] | None, strict_spe
     - Dict with constraints: {"col1": {"dtype": ..., "nullable": False, "required": False, ...}}
 
     Invalid column types (like integers) are silently ignored for backwards compatibility
-    unless strict_specs=True.
+    unless strict_specs=True, in which case a TypeError is raised with the offending
+    index and type name.
     """
     result = ParsedColumnSpec()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,9 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-from daffy.config import clear_config_cache, get_checks_max_samples, get_config, get_strict
+import pytest
+
+from daffy.config import clear_config_cache, get_checks_max_samples, get_config, get_strict, get_strict_specs
 
 
 def test_get_config_default() -> None:
@@ -33,6 +35,22 @@ def test_get_strict_override() -> None:
         assert get_strict(False) is False
 
 
+def test_get_strict_specs_default() -> None:
+    with patch("daffy.config.get_config", return_value={"strict_specs": False}):
+        assert get_strict_specs() is False
+
+    with patch("daffy.config.get_config", return_value={"strict_specs": True}):
+        assert get_strict_specs() is True
+
+
+def test_get_strict_specs_override() -> None:
+    with patch("daffy.config.get_config", return_value={"strict_specs": False}):
+        assert get_strict_specs(True) is True
+
+    with patch("daffy.config.get_config", return_value={"strict_specs": True}):
+        assert get_strict_specs(False) is False
+
+
 def test_config_from_pyproject() -> None:
     """Test loading configuration from pyproject.toml."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -51,6 +69,42 @@ strict = true
 
             config = load_config()
             assert config["strict"] is True
+
+
+def test_strict_specs_from_pyproject() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+            f.write("""
+[tool.daffy]
+strict_specs = true
+            """)
+
+        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
+            from daffy.config import load_config
+
+            clear_config_cache()
+            config = load_config()
+            assert config["strict_specs"] is True
+
+
+def test_config_strict_specs_string_raises_error() -> None:
+    """Test that non-boolean strict_specs config raises TypeError."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+            f.write("""
+[tool.daffy]
+strict_specs = "true"
+            """)
+
+        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
+            from daffy.config import load_config
+
+            clear_config_cache()
+
+            with pytest.raises(TypeError) as exc_info:
+                load_config()
+            assert "strict_specs" in str(exc_info.value)
+            assert "boolean" in str(exc_info.value)
 
 
 def test_load_config_returns_default_when_file_not_found() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,7 @@ def test_get_strict_override() -> None:
 
 
 def test_get_strict_specs_default() -> None:
+    """Verify default strict_specs value is read from config."""
     with patch("daffy.config.get_config", return_value={"strict_specs": False}):
         assert get_strict_specs() is False
 
@@ -44,6 +45,7 @@ def test_get_strict_specs_default() -> None:
 
 
 def test_get_strict_specs_override() -> None:
+    """Verify strict_specs override argument takes precedence over config."""
     with patch("daffy.config.get_config", return_value={"strict_specs": False}):
         assert get_strict_specs(True) is True
 
@@ -72,6 +74,7 @@ strict = true
 
 
 def test_strict_specs_from_pyproject() -> None:
+    """Verify strict_specs value is read from pyproject config."""
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
             f.write("""
@@ -226,8 +229,6 @@ checks_max_samples = 10
 
 def test_config_strict_string_raises_error() -> None:
     """Test that non-boolean strict config raises TypeError."""
-    import pytest
-
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
             f.write("""
@@ -248,8 +249,6 @@ strict = "false"
 
 def test_config_max_samples_string_raises_error() -> None:
     """Test that non-integer max_samples config raises TypeError."""
-    import pytest
-
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
             f.write("""
@@ -270,8 +269,6 @@ checks_max_samples = "five"
 
 def test_config_max_samples_zero_raises_error() -> None:
     """Test that max_samples < 1 raises ValueError."""
-    import pytest
-
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
             f.write("""
@@ -328,8 +325,6 @@ row_validation_max_errors = 1
 
 def test_config_row_validation_max_errors_zero_raises_error() -> None:
     """Test that row_validation_max_errors < 1 raises ValueError."""
-    import pytest
-
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
             f.write("""

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -387,7 +387,7 @@ def test_check_columns_invalid_column_type_in_list_raises_when_strict_specs_enab
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
 
     with (
-        patch("daffy.validators.builder.get_strict_specs", return_value=True),
+        patch("daffy.decorators.get_strict_specs", return_value=True),
         pytest.raises(TypeError, match="Invalid column spec at index 1"),
     ):
         process(df)
@@ -416,7 +416,7 @@ def test_check_columns_invalid_column_key_in_dict_raises_when_strict_specs_enabl
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
 
     with (
-        patch("daffy.validators.builder.get_strict_specs", return_value=True),
+        patch("daffy.decorators.get_strict_specs", return_value=True),
         pytest.raises(TypeError, match="Invalid column key at index 1"),
     ):
         process(df)

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import patch
 
 import pandas as pd
 import polars as pl
@@ -376,6 +377,22 @@ def test_check_columns_handles_invalid_column_type_in_list() -> None:
     assert len(result) == 2
 
 
+def test_check_columns_invalid_column_type_in_list_raises_when_strict_specs_enabled() -> None:
+    columns: Any = ["A", 123]
+
+    @df_in(columns=columns)
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+
+    with (
+        patch("daffy.validators.builder.get_strict_specs", return_value=True),
+        pytest.raises(TypeError, match="Invalid column spec at index 1"),
+    ):
+        process(df)
+
+
 def test_check_columns_handles_invalid_column_key_in_dict() -> None:
     """Invalid column keys in dict spec are silently ignored."""
     columns: Any = {"A": "int64", 123: "int64"}
@@ -387,6 +404,22 @@ def test_check_columns_handles_invalid_column_key_in_dict() -> None:
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     result = process(df)
     assert len(result) == 2
+
+
+def test_check_columns_invalid_column_key_in_dict_raises_when_strict_specs_enabled() -> None:
+    columns: Any = {"A": "int64", 123: "int64"}
+
+    @df_in(columns=columns)
+    def process(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+
+    with (
+        patch("daffy.validators.builder.get_strict_specs", return_value=True),
+        pytest.raises(TypeError, match="Invalid column key at index 1"),
+    ):
+        process(df)
 
 
 def test_check_columns_handles_invalid_column_key_with_constraints() -> None:

--- a/tests/validators/test_builder.py
+++ b/tests/validators/test_builder.py
@@ -348,3 +348,21 @@ class TestPipelineIntegration:
 
         with pytest.raises(AssertionError, match="Missing columns"):
             pipeline.run(ctx)
+
+
+class TestStrictSpecs:
+    def test_strict_specs_raises_on_invalid_column_type(self) -> None:
+        with pytest.raises(TypeError, match="Invalid column spec at index 1"):
+            build_validation_pipeline(
+                columns=["a", 123],
+                strict=False,
+                strict_specs=True,
+                lazy=False,
+                composite_unique=None,
+                row_validator=None,
+                min_rows=None,
+                max_rows=None,
+                exact_rows=None,
+                allow_empty=True,
+                df_columns=["a"],
+            )

--- a/tests/validators/test_builder.py
+++ b/tests/validators/test_builder.py
@@ -23,6 +23,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=None,
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -39,6 +40,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=None,
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -56,6 +58,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=None,
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -73,6 +76,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=["a", "b", "c"],
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -89,6 +93,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=["a", "b"],
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -105,6 +110,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns={"a": "int64"},
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -121,6 +127,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns={"a": {"nullable": False}},
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -137,6 +144,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns={"a": {"unique": True}},
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -153,6 +161,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns={"a": {"checks": {"gt": 0}}},
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -169,6 +178,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=["a"],
             strict=True,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -185,6 +195,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=None,
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=[["a", "b"]],
             row_validator=None,
@@ -204,6 +215,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=None,
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=TestModel,
@@ -223,6 +235,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=None,
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=TestModel,
@@ -240,6 +253,7 @@ class TestBuildValidationPipeline:
         pipeline = build_validation_pipeline(
             columns=None,
             strict=False,
+            strict_specs=False,
             lazy=True,
             composite_unique=None,
             row_validator=None,
@@ -258,6 +272,7 @@ class TestRegexExpansion:
         pipeline = build_validation_pipeline(
             columns={"r/col_\\d+/": {"nullable": False}},
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -282,6 +297,7 @@ class TestPipelineIntegration:
         pipeline = build_validation_pipeline(
             columns={"id": {"dtype": "Int64", "unique": True}, "name": {"nullable": False}},
             strict=True,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=RowModel,
@@ -299,6 +315,7 @@ class TestPipelineIntegration:
         pipeline = build_validation_pipeline(
             columns={"a": {}, "b": {"required": False}},
             strict=True,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,
@@ -316,6 +333,7 @@ class TestPipelineIntegration:
         pipeline = build_validation_pipeline(
             columns=["a", "b"],
             strict=False,
+            strict_specs=False,
             lazy=False,
             composite_unique=None,
             row_validator=None,

--- a/tests/validators/test_spec_parser.py
+++ b/tests/validators/test_spec_parser.py
@@ -1,5 +1,7 @@
 """Tests for column spec parsing."""
 
+import pytest
+
 from daffy.validators.spec_parser import parse_column_spec
 
 
@@ -84,3 +86,20 @@ class TestParseColumnSpec:
 
         assert result.required_columns == ["column_name"]
         assert len(result.required_columns) == 1
+
+    def test_invalid_column_type_in_list_is_ignored_by_default(self) -> None:
+        result = parse_column_spec(["a", 123])
+        assert result.required_columns == ["a"]
+
+    def test_invalid_column_type_in_list_raises_when_strict_specs_enabled(self) -> None:
+        with pytest.raises(TypeError, match="Invalid column spec at index 1"):
+            parse_column_spec(["a", 123], strict_specs=True)
+
+    def test_invalid_column_key_in_dict_is_ignored_by_default(self) -> None:
+        result = parse_column_spec({"a": "int64", 123: "int64"})
+        assert result.required_columns == ["a"]
+        assert result.dtype_constraints == {"a": "int64"}
+
+    def test_invalid_column_key_in_dict_raises_when_strict_specs_enabled(self) -> None:
+        with pytest.raises(TypeError, match="Invalid column key at index 1"):
+            parse_column_spec({"a": "int64", 123: "int64"}, strict_specs=True)


### PR DESCRIPTION
Summary:
- add a new config option: [tool.daffy] strict_specs (default false)
- when strict_specs=true, invalid column keys/spec types now raise TypeError instead of being silently ignored
- keep existing default behavior unchanged (invalid entries still ignored when strict_specs is false)
- wire strict-spec behavior through validation pipeline parsing
- add targeted tests in spec parser, config loading/getters, and df_in behavior
- update changelog

Verification:
- mise x -- uv run pytest tests/validators/test_spec_parser.py tests/test_df_in.py tests/test_config.py -q
- mise x -- uv run ruff check daffy/config.py daffy/validators/spec_parser.py daffy/validators/builder.py tests/test_config.py tests/test_df_in.py tests/validators/test_spec_parser.py
- mise x -- uv run ruff format --check daffy/config.py daffy/validators/spec_parser.py daffy/validators/builder.py tests/test_config.py tests/test_df_in.py tests/validators/test_spec_parser.py
- mise x -- uv run pyrefly check .
- mise x -- uv run vulture daffy --min-confidence 100
- XDG_CACHE_HOME=/tmp mise x -- dprint check
- mise x -- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional strict column-spec validation mode: when enabled, invalid column keys or specs raise errors instead of being silently ignored.

* **Documentation**
  * Changelog updated to document the new strict_specs configuration option and how to enable it.

* **Tests**
  * Added and updated tests covering strict vs. non-strict parsing, config loading, and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->