### PR TITLE
Allow @df_in(["col1", "col2"]) shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- `@df_in(["col1", "col2"])` shorthand: pass columns as the first positional argument
+
 ## 2.6.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Works with whatever DataFrame library you already have installed. Python 3.10–
 ```python
 from daffy import df_in, df_out
 
-@df_in(columns=["price", "bedrooms", "location"])
-@df_out(columns=["price_per_room", "price_category"])
+@df_in(["price", "bedrooms", "location"])
+@df_out(["price_per_room", "price_category"])
 def analyze_housing(houses_df):
     # Transform raw housing data into price analysis
     return analyzed_df
@@ -70,8 +70,8 @@ Most DataFrame validation tools are schema-first (define schemas separately) or 
 ```python
 from daffy import df_in, df_out
 
-@df_in(columns=["Brand", "Price"])
-@df_out(columns=["Brand", "Price", "Discount"])
+@df_in(["Brand", "Price"])
+@df_out(["Brand", "Price", "Discount"])
 def apply_discount(df):
     df = df.copy()
     df["Discount"] = df["Price"] * 0.1
@@ -83,7 +83,7 @@ def apply_discount(df):
 Match dynamic column names with regex patterns:
 
 ```python
-@df_in(columns=["id", "r/feature_\\d+/"])
+@df_in(["id", "r/feature_\\d+/"])
 def process_features(df):
     return df
 ```
@@ -93,7 +93,7 @@ def process_features(df):
 Vectorized checks with zero row iteration overhead:
 
 ```python
-@df_in(columns={
+@df_in({
     "price": {"checks": {"gt": 0, "lt": 10000}},
     "status": {"checks": {"isin": ["active", "pending", "closed"]}},
     "email": {"checks": {"str_regex": r"^[^@]+@[^@]+\.[^@]+$"}},
@@ -108,13 +108,11 @@ Also supported: `notin`, `str_startswith`, `str_endswith`, `str_contains`, `str_
 ### Nullability and uniqueness
 
 ```python
-@df_in(
-    columns={
-        "user_id": {"unique": True, "nullable": False},  # user_id must be unique and not null
-        "email": {"nullable": False},  # email cannot be null
-        "age": {"dtype": "int64"},
-    }
-)
+@df_in({
+    "user_id": {"unique": True, "nullable": False},  # user_id must be unique and not null
+    "email": {"nullable": False},  # email cannot be null
+    "age": {"dtype": "int64"},
+})
 def clean_users(df):
     return df
 ```

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -174,7 +174,7 @@ def df_out(
 
 @overload
 def df_in(
-    name: ColumnsDef,
+    columns: ColumnsDef,
     /,
     *,
     strict: bool | None = ...,

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from functools import wraps
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -172,8 +172,39 @@ def df_out(
     return wrapper_df_out
 
 
+@overload
 def df_in(
-    name: str | None = None,
+    name: ColumnsDef,
+    /,
+    *,
+    strict: bool | None = ...,
+    lazy: bool | None = ...,
+    composite_unique: list[list[str]] | None = ...,
+    row_validator: type[BaseModel] | None = ...,
+    min_rows: int | None = ...,
+    max_rows: int | None = ...,
+    exact_rows: int | None = ...,
+    allow_empty: bool | None = ...,
+) -> Callable[[Callable[..., InReturnT]], Callable[..., InReturnT]]: ...
+
+
+@overload
+def df_in(
+    name: str | None = ...,
+    columns: ColumnsDef = ...,
+    strict: bool | None = ...,
+    lazy: bool | None = ...,
+    composite_unique: list[list[str]] | None = ...,
+    row_validator: type[BaseModel] | None = ...,
+    min_rows: int | None = ...,
+    max_rows: int | None = ...,
+    exact_rows: int | None = ...,
+    allow_empty: bool | None = ...,
+) -> Callable[[Callable[..., InReturnT]], Callable[..., InReturnT]]: ...
+
+
+def df_in(
+    name: str | ColumnsDef | None = None,
     columns: ColumnsDef = None,
     strict: bool | None = None,
     lazy: bool | None = None,
@@ -213,6 +244,14 @@ def df_in(
         Callable: Decorated function with preserved return type
 
     """
+    if name is not None and not isinstance(name, str):
+        if columns is not None:
+            raise TypeError(
+                "Cannot pass columns as both the first positional argument and the 'columns' keyword argument"
+            )
+        columns = name
+        name = None
+
     _validate_composite_unique(composite_unique)
     _validate_shape_constraints(min_rows, max_rows, exact_rows)
 

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -221,6 +221,8 @@ def df_in(
 
     Args:
         name (Optional[str], optional): Name of the parameter that contains a DataFrame. Defaults to None.
+            Alternatively, a column specification (list or dict) may be passed as the first positional
+            argument as a shorthand for ``columns=`` — e.g. ``@df_in(["col1", "col2"])``.
         columns (Union[Sequence[str], Dict[str, Any]], optional): Sequence or dict that describes expected columns
             of the DataFrame.
             Sequence can contain regex patterns in format "r/pattern/" (e.g., "r/Col[0-9]+/").

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -9,7 +9,7 @@ You can use regex patterns to match column names that follow a specific pattern.
 Define a regex pattern by using the format `"r/pattern/"`:
 
 ```python
-@df_in(columns=["Brand", "r/Price_\d+/"])
+@df_in(["Brand", "r/Price_\d+/"])
 def process_data(df):
     # This will accept DataFrames with columns like "Brand", "Price_1", "Price_2", etc.
     ...
@@ -33,7 +33,7 @@ Regex patterns are also considered in strict mode. Any column matching a regex p
 You can use regex patterns in dictionaries that specify data types as well:
 
 ```python
-@df_in(columns={"Brand": "object", "r/Price_\d+/": "int64"})
+@df_in({"Brand": "object", "r/Price_\d+/": "int64"})
 def process_data(df):
     # This will check that all columns matching "Price_\d+" have int64 dtype
     ...
@@ -55,7 +55,7 @@ AssertionError: Column Price_2 in function 'process_data' parameter 'df' has wro
 You can validate that columns contain no null values using the rich column spec format:
 
 ```python
-@df_in(columns={"price": {"nullable": False}})
+@df_in({"price": {"nullable": False}})
 def process_prices(df):
     # price column must not contain any null/NaN values
     ...
@@ -66,7 +66,7 @@ def process_prices(df):
 Nullable validation can be combined with dtype validation:
 
 ```python
-@df_in(columns={"price": {"dtype": "float64", "nullable": False}})
+@df_in({"price": {"dtype": "float64", "nullable": False}})
 def process_prices(df):
     # price must be float64 AND contain no nulls
     ...
@@ -77,7 +77,7 @@ def process_prices(df):
 Nullable validation works with regex patterns, applying to all matched columns:
 
 ```python
-@df_in(columns={"r/Price_\\d+/": {"nullable": False}})
+@df_in({"r/Price_\\d+/": {"nullable": False}})
 def process_data(df):
     # All columns matching Price_1, Price_2, etc. must not contain nulls
     ...
@@ -98,7 +98,7 @@ AssertionError: Column 'price' in function 'process_prices' parameter 'df' conta
 You can validate that columns contain only unique values using the rich column spec format:
 
 ```python
-@df_in(columns={"user_id": {"unique": True}})
+@df_in({"user_id": {"unique": True}})
 def process_users(df):
     # user_id column must not contain any duplicate values
     ...
@@ -109,7 +109,7 @@ def process_users(df):
 Uniqueness validation can be combined with dtype and nullable validation:
 
 ```python
-@df_in(columns={"user_id": {"dtype": "int64", "unique": True, "nullable": False}})
+@df_in({"user_id": {"dtype": "int64", "unique": True, "nullable": False}})
 def process_users(df):
     # user_id must be int64, contain no nulls, AND have no duplicates
     ...
@@ -120,7 +120,7 @@ def process_users(df):
 Uniqueness validation works with regex patterns, applying to all matched columns:
 
 ```python
-@df_in(columns={"r/ID_\\d+/": {"unique": True}})
+@df_in({"r/ID_\\d+/": {"unique": True}})
 def process_data(df):
     # All columns matching ID_1, ID_2, etc. must have unique values
     ...
@@ -235,7 +235,7 @@ AssertionError: DataFrame in function 'process_data' parameter 'df' has 8 rows b
 By default, all specified columns are required. You can mark columns as optional using `required=False`:
 
 ```python
-@df_in(columns={
+@df_in({
     "user_id": {"dtype": "int64"},
     "nickname": {"dtype": "object", "required": False}
 })
@@ -250,7 +250,7 @@ def process_users(df):
 - If an optional column is present, all other validations (dtype, nullable, unique) still apply
 
 ```python
-@df_in(columns={
+@df_in({
     "discount": {"dtype": "float64", "nullable": False, "required": False}
 })
 def process_orders(df):
@@ -263,7 +263,7 @@ def process_orders(df):
 Optional columns work with regex patterns:
 
 ```python
-@df_in(columns={
+@df_in({
     "id": {"dtype": "int64"},
     "r/extra_\\d+/": {"dtype": "object", "required": False}
 })
@@ -281,7 +281,7 @@ By default, `required=True`, meaning all columns must exist. This preserves back
 You can validate column values using vectorized checks. This is faster than row-by-row validation because it uses vectorized DataFrame operations:
 
 ```python
-@df_in(columns={
+@df_in({
     "price": {"checks": {"gt": 0}},
     "score": {"checks": {"between": (0, 100)}},
     "status": {"checks": {"isin": ["active", "pending", "closed"]}},
@@ -315,7 +315,7 @@ def process_data(df):
 You can combine multiple checks on a single column:
 
 ```python
-@df_in(columns={
+@df_in({
     "price": {"checks": {"gt": 0, "lt": 10000}},
     "age": {"checks": {"ge": 0, "le": 120}},
 })
@@ -328,7 +328,7 @@ def process_data(df):
 Checks work alongside other column validations:
 
 ```python
-@df_in(columns={
+@df_in({
     "price": {
         "dtype": "float64",
         "nullable": False,
@@ -344,7 +344,7 @@ def process_data(df):
 Checks apply to all columns matching a regex pattern:
 
 ```python
-@df_in(columns={
+@df_in({
     "r/score_\\d+/": {"checks": {"between": (0, 100)}}
 })
 def process_data(df):
@@ -357,7 +357,7 @@ def process_data(df):
 If a column is optional and missing, checks are skipped:
 
 ```python
-@df_in(columns={
+@df_in({
     "discount": {"required": False, "checks": {"ge": 0, "le": 1}}
 })
 def process_data(df):
@@ -370,7 +370,7 @@ def process_data(df):
 For validation logic not covered by built-in checks, you can use custom functions. The function receives a [Narwhals Series](https://narwhals-dev.github.io/narwhals/) and should return a boolean Series where `True` means valid:
 
 ```python
-@df_in(columns={
+@df_in({
     "price": {"checks": {
         "gt": 0,  # built-in check
         "no_outliers": lambda s: s < s.mean() * 10  # custom check
@@ -389,7 +389,7 @@ AssertionError: Column 'price' failed check 'no_outliers': 3 values failed. Exam
 Custom checks can use any Narwhals Series operations:
 
 ```python
-@df_in(columns={
+@df_in({
     "email": {"checks": {
         "has_at": lambda s: s.str.contains("@"),
         "reasonable_length": lambda s: (s.str.len_chars() >= 5) & (s.str.len_chars() <= 254)
@@ -467,7 +467,7 @@ AssertionError: Row validation failed for 2 out of 100 rows:
 You can validate both columns and row data:
 
 ```python
-@df_in(columns=["name", "price", "stock"], row_validator=Product)
+@df_in(["name", "price", "stock"], row_validator=Product)
 def process_inventory(df):
     return df
 ```
@@ -529,7 +529,7 @@ def process_employees(df):
 By default, validation stops at the first error type. With `lazy=True`, all errors are collected and reported together:
 
 ```python
-@df_in(columns={
+@df_in({
     "price": {"dtype": "float64", "nullable": False},
     "quantity": {"dtype": "int64", "checks": {"gt": 0}},
     "category": "object"

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,10 @@ Validates DataFrame parameters passed to a function.
 **Examples:**
 
 ```python
+# Shorthand: columns as first positional argument
+@df_in(["a", "b", "c"])
+@df_in({"a": "int64", "b": "object"})
+
 # Simple column list
 @df_in(columns=["a", "b", "c"])
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,20 +37,16 @@ Validates DataFrame parameters passed to a function.
 **Examples:**
 
 ```python
-# Shorthand: columns as first positional argument
+# Column list
 @df_in(["a", "b", "c"])
-@df_in({"a": "int64", "b": "object"})
-
-# Simple column list
-@df_in(columns=["a", "b", "c"])
 
 # With dtypes
-@df_in(columns={"a": "int64", "b": "object"})
+@df_in({"a": "int64", "b": "object"})
 
 # With constraints
-@df_in(columns={"price": {"dtype": "float64", "nullable": False, "checks": {"gt": 0}}})
+@df_in({"price": {"dtype": "float64", "nullable": False, "checks": {"gt": 0}}})
 
-# Multiple DataFrames
+# Multiple DataFrames — use name to target specific parameters
 @df_in(name="orders", columns=["id", "total"])
 @df_in(name="customers", columns=["id", "name"])
 
@@ -58,7 +54,7 @@ Validates DataFrame parameters passed to a function.
 @df_in(row_validator=OrderModel)
 
 # Shape/lazy controls
-@df_in(columns={"email": {"nullable": False}}, lazy=True, min_rows=1, allow_empty=False)
+@df_in({"email": {"nullable": False}}, lazy=True, min_rows=1, allow_empty=False)
 ```
 
 ---
@@ -98,9 +94,9 @@ Validates the DataFrame returned by a function.
 **Examples:**
 
 ```python
-@df_out(columns=["result", "score"])
+@df_out(["result", "score"])
 
-@df_out(columns={"score": "float64"}, strict=True)
+@df_out({"score": "float64"}, strict=True)
 
 @df_out(row_validator=ResultModel)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ Import the decorators and add them to your functions:
 ```python
 from daffy import df_in, df_out
 
-@df_in(columns=["name", "price", "quantity"])
+@df_in(["name", "price", "quantity"])
 def process_orders(orders_df):
     # If orders_df is missing any of these columns,
     # Daffy raises an AssertionError immediately
@@ -37,8 +37,8 @@ That's it! When `process_orders` is called, Daffy checks that the DataFrame has 
 Validate both what goes in and what comes out:
 
 ```python
-@df_in(columns=["name", "price"])
-@df_out(columns=["name", "price", "total"])
+@df_in(["name", "price"])
+@df_out(["name", "price", "total"])
 def calculate_totals(df):
     df = df.copy()
     df["total"] = df["price"] * 1.1  # Add 10% tax
@@ -52,7 +52,7 @@ If the returned DataFrame doesn't have the expected columns, you'll know immedia
 Check data types alongside column names:
 
 ```python
-@df_in(columns={
+@df_in({
     "name": "object",
     "price": "float64",
     "quantity": "int64"
@@ -68,7 +68,7 @@ If `price` is accidentally an `int64` instead of `float64`, Daffy catches it.
 Validate column values without row iteration:
 
 ```python
-@df_in(columns={
+@df_in({
     "price": {"dtype": "float64", "checks": {"gt": 0}},
     "quantity": {"dtype": "int64", "checks": {"ge": 0}},
     "status": {"checks": {"isin": ["pending", "shipped", "delivered"]}}

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -11,14 +11,14 @@ import pandas as pd
 from daffy import df_in, df_out
 
 
-@df_out(columns={"product_id": "int64", "name": "object", "price": "float64", "category": "object"})
+@df_out({"product_id": "int64", "name": "object", "price": "float64", "category": "object"})
 def load_products(filepath: str) -> pd.DataFrame:
     """Load product data from CSV."""
     return pd.read_csv(filepath)
 
 
-@df_in(columns=["product_id", "name", "price", "category"])
-@df_out(columns=["product_id", "name", "price", "category", "price_tier"])
+@df_in(["product_id", "name", "price", "category"])
+@df_out(["product_id", "name", "price", "category", "price_tier"])
 def add_price_tier(df: pd.DataFrame) -> pd.DataFrame:
     """Add price tier classification."""
     df = df.copy()
@@ -30,8 +30,8 @@ def add_price_tier(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-@df_in(columns=["product_id", "name", "price", "category", "price_tier"])
-@df_out(columns=["category", "avg_price", "product_count"])
+@df_in(["product_id", "name", "price", "category", "price_tier"])
+@df_out(["category", "avg_price", "product_count"])
 def summarize_by_category(df: pd.DataFrame) -> pd.DataFrame:
     """Aggregate products by category."""
     return df.groupby("category").agg(
@@ -70,7 +70,7 @@ PRODUCTS_DB = pd.DataFrame({
 })
 
 
-@df_out(columns={"id": "int64", "name": "object", "price": "float64", "in_stock": "bool"})
+@df_out({"id": "int64", "name": "object", "price": "float64", "in_stock": "bool"})
 def get_products_df(in_stock_only: bool = False) -> pd.DataFrame:
     """Fetch products, optionally filtering to in-stock items."""
     df = PRODUCTS_DB.copy()
@@ -109,8 +109,8 @@ class DataPayload(BaseModel):
     data: list[dict]
 
 
-@df_in(columns={"value": {"dtype": "float64", "checks": {"gt": 0}}})
-@df_out(columns=["value", "result"])
+@df_in({"value": {"dtype": "float64", "checks": {"gt": 0}}})
+@df_out(["value", "result"])
 def transform(df: pd.DataFrame) -> pd.DataFrame:
     """Transform values - validates input and output."""
     df = df.copy()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,12 +10,38 @@ Start by importing the needed decorators:
 from daffy import df_in, df_out
 ```
 
+## Calling Styles
+
+Both `@df_in` and `@df_out` accept columns as the first positional argument. These two forms are equivalent:
+
+```python
+# Shorthand — columns as first positional argument
+@df_in(["Brand", "Price"])
+@df_in({"Brand": "object", "Price": "int64"})
+
+# Explicit keyword
+@df_in(columns=["Brand", "Price"])
+@df_in(columns={"Brand": "object", "Price": "int64"})
+```
+
+Use whichever style you prefer. The shorthand is more concise; the keyword form reads well when combined with other parameters:
+
+```python
+@df_in(columns=["Brand", "Price"], strict=True)
+```
+
+When validating a specific named parameter, pass `name` as a keyword:
+
+```python
+@df_in(name="car_df", columns=["Brand", "Price"])
+```
+
 ## Input Validation
 
 To check a DataFrame input to a function, annotate the function with `@df_in`. For example the following function expects to get a DataFrame with columns `Brand` and `Price`:
 
 ```python
-@df_in(columns=["Brand", "Price"])
+@df_in(["Brand", "Price"])
 def process_cars(car_df):
     # do stuff with cars
 ```
@@ -42,7 +68,7 @@ def process_cars(car_df, brand_df):
 To check that a function returns a DataFrame with specific columns, use `@df_out` decorator:
 
 ```python
-@df_out(columns=["Brand", "Price"])
+@df_out(["Brand", "Price"])
 def get_all_cars():
     # get those cars
     return all_cars_df
@@ -61,8 +87,8 @@ The error message clearly indicates that this is a **return value** validation f
 To check both input and output, just use both annotations on the same function:
 
 ```python
-@df_in(columns=["Brand", "Price"])
-@df_out(columns=["Brand", "Price"])
+@df_in(["Brand", "Price"])
+@df_out(["Brand", "Price"])
 def filter_cars(car_df):
     # filter some cars
     return filtered_cars_df
@@ -98,7 +124,7 @@ AssertionError("Column Price in function 'process_cars' parameter 'car_df' has w
 You can enable strict-mode for both `@df_in` and `@df_out`. This will raise an error if the DataFrame contains columns not defined in the annotation:
 
 ```python
-@df_in(columns=["Brand"], strict=True)
+@df_in(["Brand"], strict=True)
 def process_cars(car_df):
     # do stuff with cars
 ```

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -517,7 +517,7 @@ def test_df_in_list_shorthand_missing_column(df: IntoDataFrame) -> None:
     with pytest.raises(AssertionError) as excinfo:
         test_fn(df)
 
-    assert "Missing columns: ['NonExistent']" in str(excinfo.value)
+    assert "Missing columns: ['NonExistent'] in function 'test_fn' parameter 'my_input'" in str(excinfo.value)
 
 
 def test_df_in_shorthand_conflict_raises_type_error() -> None:

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -481,3 +481,46 @@ def test_function_name_appears_in_dtype_mismatch_exception() -> None:
     assert "another_test_function" in str(excinfo.value)
     assert "Column Price" in str(excinfo.value)
     assert "wrong dtype" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
+def test_df_in_list_shorthand(df: IntoDataFrame) -> None:
+    @df_in(["Brand", "Price"])
+    def test_fn(my_input: Any) -> Any:
+        return my_input
+
+    test_fn(df)
+
+
+def test_df_in_dict_shorthand(basic_pandas_df: pd.DataFrame) -> None:
+    @df_in({"Brand": "object", "Price": "int64"})
+    def test_fn(my_input: Any) -> Any:
+        return my_input
+
+    test_fn(basic_pandas_df)
+
+
+@pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
+def test_df_in_list_shorthand_missing_column(df: IntoDataFrame) -> None:
+    @df_in(["Brand", "NonExistent"])
+    def test_fn(my_input: Any) -> Any:
+        return my_input
+
+    with pytest.raises(AssertionError) as excinfo:
+        test_fn(df)
+
+    assert "Missing columns: ['NonExistent']" in str(excinfo.value)
+
+
+def test_df_in_shorthand_conflict_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="Cannot pass columns as both"):
+        df_in(["a"], columns=["b"])  # type: ignore[no-matching-overload]
+
+
+@pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
+def test_df_in_string_positional_still_works(df: IntoDataFrame) -> None:
+    @df_in("my_input", columns=["Brand", "Price"])
+    def test_fn(my_input: Any) -> Any:
+        return my_input
+
+    test_fn(df)

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -500,6 +500,14 @@ def test_df_in_dict_shorthand(basic_pandas_df: pd.DataFrame) -> None:
     test_fn(basic_pandas_df)
 
 
+def test_df_in_dict_shorthand_polars(basic_polars_df: pl.DataFrame) -> None:
+    @df_in({"Brand": pl.datatypes.String, "Price": pl.datatypes.Int64})
+    def test_fn(my_input: Any) -> Any:
+        return my_input
+
+    test_fn(basic_polars_df)
+
+
 @pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
 def test_df_in_list_shorthand_missing_column(df: IntoDataFrame) -> None:
     @df_in(["Brand", "NonExistent"])


### PR DESCRIPTION
## Summary

- Detect when `df_in`'s first positional argument is a non-string (list, dict) and route it to the `columns` parameter, enabling `@df_in(["col1", "col2"])` as shorthand for `@df_in(columns=["col1", "col2"])`
- Add `@overload` signatures so type checkers accept the new calling convention
- Raise `TypeError` when columns are passed as both positional and keyword argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Column specifications in decorators now accept positional arguments as the first parameter, supporting shorthand syntax alongside the existing keyword argument form.

* **Documentation**
  * Updated all documentation examples to demonstrate the new positional argument syntax.

* **Tests**
  * Added test coverage for the new shorthand column specification syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->