### PR TITLE
Release 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `@df_in(["col1", "col2"])` shorthand: pass columns as the first positional argument
-- Opt-in strict column spec validation via `[tool.daffy] strict_specs = true` for invalid column keys/types
+- Opt-in `strict_specs` mode (`[tool.daffy] strict_specs = true`): raises `TypeError` on invalid column spec keys or types instead of silently ignoring them
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 2.7.0
 
 ### Added
 
 - `@df_in(["col1", "col2"])` shorthand: pass columns as the first positional argument
+- Opt-in strict column spec validation via `[tool.daffy] strict_specs = true` for invalid column keys/types
+
+### Changed
+
+- Config discovery now searches `pyproject.toml` from the current directory up through parent directories
+- Configuration caching is now keyed by current working directory for deterministic behavior across cwd changes
+- Unnamed `df_in` now selects the first DataFrame-like argument instead of always taking the first positional argument
 
 ## 2.6.1
 
@@ -16,15 +23,11 @@ All notable changes to this project will be documented in this file.
 - Early import failure now triggers only when none of the supported DataFrame libraries are installed
 - Updated optional dependency tests and isolation docs/scripts to align with the expanded backend detection contract
 - Synced API docs and README examples with current `df_in`/`df_out`/`df_log` signatures and built-in check names
-- Config discovery now searches `pyproject.toml` from the current directory up through parent directories
-- Configuration caching is now keyed by current working directory for deterministic behavior across cwd changes
-- Unnamed `df_in` now selects the first DataFrame-like argument instead of always taking the first positional argument
 
 ### Added
 
 - Declared `pydantic` optional dependency extra so `pip install 'daffy[pydantic]'` matches runtime install guidance
 - Added docs contract tests to detect signature/example drift in `README.md` and `docs/api.md`
-- Added opt-in strict column spec validation via `[tool.daffy] strict_specs = true` for invalid column keys/types
 
 ## 2.6.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "2.6.1"
+version = "2.7.0"
 description = "Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow."
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },


### PR DESCRIPTION
## Summary

- Moves #170 and #174 entries out of 2.6.1 section (they were merged after the tag)
- Consolidates all four post-2.6.1 features under a new 2.7.0 heading
- Bumps version to 2.7.0
- Tag `v2.7.0` pushed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in strict column specification validation that enforces type/key checks for column specs

* **Improvements**
  * Config discovery now searches parent directories for more flexible setup
  * Configuration caching keyed to the current working directory for consistent behavior
  * Unnamed DataFrame argument selection improved to pick the first DataFrame-like input

* **Release**
  * Published as version 2.7.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->