### PR TITLE
Enable Renovate auto-merge for dev deps and GH Actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,8 @@
         "coverage",
         "pytest-cov",
         "pre-commit"
-      ]
+      ],
+      "automerge": true
     },
     {
       "groupName": "test-dependencies",
@@ -35,7 +36,8 @@
     },
     {
       "groupName": "github-actions",
-      "matchManagers": ["github-actions"]
+      "matchManagers": ["github-actions"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Enable `automerge: true` for `dev-dependencies` (ruff, pyrefly, skylos, coverage, pytest-cov, pre-commit) and `github-actions` groups
- Test dependencies remain manual review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Enabled automatic merging for dependency update groups to streamline maintenance workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->