### PR TITLE
fix(deps): update pypi-publish tag for Renovate lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae # v2


### PR DESCRIPTION
## Summary
- The `release/v1` tag no longer exists in `pypa/gh-action-pypi-publish`, causing Renovate digest lookup failures on the dependency dashboard
- Updated the version comment to `v1.13.0` (same commit SHA, just the correct tag name)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration annotations for release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->