### PR TITLE
ci: wire skylos into lint gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
           uv run ruff format --diff
           uv run pyrefly check .
           uv run vulture daffy --min-confidence 100
+          uv run skylos . --gate --strict --no-upload
           dprint check
 
   # Coverage on latest Python only

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Skylos cache
+.skylos/
+
 # pytype static type analyzer
 .pytype/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ uv run pytest --cov
 uv run ruff check .
 uv run ruff format --check .
 uv run pyrefly check .
+uv run skylos . --gate --strict --no-upload
 ```
 
 Notes:


### PR DESCRIPTION
## Summary
- Runs `skylos . --gate --strict --no-upload` in the lint job alongside the existing `vulture` check.
- `--strict` is required for the gate to fail on any finding; bare `--gate` only fails when the overall grade drops, so low-confidence issues would slip through.
- Updated `CLAUDE.md` quality-gates list to match.

## Gate verification
Temporarily added an unused function + unused local in `daffy/utils.py`:
- `skylos . --gate --strict --no-upload` exited **1** with `Quality Gate: FAILED — Strict mode: 2 issue(s) found`.
- After reverting, clean tree exits **0** / `Quality Gate: PASSED`.

## Follow-up
- `vulture` and `skylos` now overlap on dead-code detection; worth deciding whether to drop `vulture --min-confidence 100` in a later PR.