### PR TITLE
refactor: simplify test assertions and pathlib usage

### DIFF
--- a/daffy/validators/__init__.py
+++ b/daffy/validators/__init__.py
@@ -3,7 +3,12 @@
 from daffy.validators.base import SkippableValidator, Validator
 from daffy.validators.builder import build_validation_pipeline
 from daffy.validators.checks import ChecksValidator
-from daffy.validators.columns import ColumnsExistValidator, DtypeValidator, NullableValidator, StrictModeValidator
+from daffy.validators.columns import (
+    ColumnsExistValidator,
+    DtypeValidator,
+    NullableValidator,
+    StrictModeValidator,
+)
 from daffy.validators.context import ValidationContext
 from daffy.validators.pipeline import ValidationPipeline
 from daffy.validators.rows import RowValidator

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -12,7 +12,7 @@ class TestComparisonChecks:
         series = pd.Series([1, 2, 3])
         fail_count, samples = apply_check(series, "gt", 0)
         assert fail_count == 0
-        assert samples == []
+        assert not samples
 
     def test_gt_fails(self) -> None:
         series = pd.Series([0, 1, 2, 3])
@@ -301,13 +301,13 @@ class TestEdgeCases:
         series = pd.Series([], dtype=float)
         fail_count, samples = apply_check(series, "gt", 0)
         assert fail_count == 0
-        assert samples == []
+        assert not samples
 
     def test_single_value_passes(self) -> None:
         series = pd.Series([5])
         fail_count, samples = apply_check(series, "gt", 0)
         assert fail_count == 0
-        assert samples == []
+        assert not samples
 
     def test_single_value_fails(self) -> None:
         series = pd.Series([-1])
@@ -332,7 +332,7 @@ class TestValidateChecks:
 
         nws = nw.from_native(df, eager_only=True)["price"]
         violations = validate_checks(nws, "price", {"gt": 0})
-        assert violations == []
+        assert not violations
 
     def test_single_check_fails(self) -> None:
         df = pd.DataFrame({"price": [0, 1, 2]})
@@ -351,7 +351,7 @@ class TestValidateChecks:
 
         nws = nw.from_native(df, eager_only=True)["score"]
         violations = validate_checks(nws, "score", {"gt": 0, "lt": 100})
-        assert violations == []
+        assert not violations
 
     def test_multiple_checks_one_fails(self) -> None:
         df = pd.DataFrame({"score": [50, 60, 150]})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,13 @@ from unittest.mock import patch
 
 import pytest
 
-from daffy.config import clear_config_cache, get_checks_max_samples, get_config, get_strict, get_strict_specs
+from daffy.config import (
+    clear_config_cache,
+    get_checks_max_samples,
+    get_config,
+    get_strict,
+    get_strict_specs,
+)
 
 
 def test_get_config_default() -> None:
@@ -57,7 +63,7 @@ def test_config_from_pyproject() -> None:
     """Test loading configuration from pyproject.toml."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create a mock pyproject.toml file
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 strict = true
@@ -76,7 +82,7 @@ strict = true
 def test_strict_specs_from_pyproject() -> None:
     """Verify strict_specs value is read from pyproject config."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 strict_specs = true
@@ -93,7 +99,7 @@ strict_specs = true
 def test_config_strict_specs_string_raises_error() -> None:
     """Test that non-boolean strict_specs config raises TypeError."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 strict_specs = "true"
@@ -118,7 +124,7 @@ def test_load_config_returns_default_when_file_not_found() -> None:
 
 def test_load_config_returns_default_when_toml_malformed() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("invalid toml [[[")
 
         with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
@@ -172,7 +178,7 @@ def test_find_config_file_prefers_nearest_parent() -> None:
 
 def test_load_config_without_strict_setting() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 other_setting = "value"
@@ -187,7 +193,7 @@ other_setting = "value"
 
 def test_load_config_daffy_section_without_strict() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 some_other_setting = "value"
@@ -212,7 +218,7 @@ def test_get_checks_max_samples_override() -> None:
 
 def test_checks_max_samples_from_pyproject() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 checks_max_samples = 10
@@ -230,7 +236,7 @@ checks_max_samples = 10
 def test_config_strict_string_raises_error() -> None:
     """Test that non-boolean strict config raises TypeError."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 strict = "false"
@@ -250,7 +256,7 @@ strict = "false"
 def test_config_max_samples_string_raises_error() -> None:
     """Test that non-integer max_samples config raises TypeError."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 checks_max_samples = "five"
@@ -270,7 +276,7 @@ checks_max_samples = "five"
 def test_config_max_samples_zero_raises_error() -> None:
     """Test that max_samples < 1 raises ValueError."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 checks_max_samples = 0
@@ -290,7 +296,7 @@ checks_max_samples = 0
 def test_config_max_samples_one_passes() -> None:
     """Test that max_samples = 1 is valid (boundary value)."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 checks_max_samples = 1
@@ -308,7 +314,7 @@ checks_max_samples = 1
 def test_config_row_validation_max_errors_one_passes() -> None:
     """Test that row_validation_max_errors = 1 is valid (boundary value)."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 row_validation_max_errors = 1
@@ -326,7 +332,7 @@ row_validation_max_errors = 1
 def test_config_row_validation_max_errors_zero_raises_error() -> None:
     """Test that row_validation_max_errors < 1 raises ValueError."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
+        with Path(os.path.join(tmpdir, "pyproject.toml")).open("w") as f:
             f.write("""
 [tool.daffy]
 row_validation_max_errors = 0

--- a/tests/test_custom_checks.py
+++ b/tests/test_custom_checks.py
@@ -12,7 +12,7 @@ class TestCustomCheckFunctions:
         series = pd.Series([1, 2, 3, 4, 5])
         fail_count, samples = apply_check(series, "positive", lambda s: s > 0)
         assert fail_count == 0
-        assert samples == []
+        assert not samples
 
     def test_custom_check_fails(self) -> None:
         series = pd.Series([1, -2, 3, -4, 5])
@@ -36,7 +36,7 @@ class TestCustomCheckFunctions:
         series = pd.Series([], dtype=float)
         fail_count, samples = apply_check(series, "positive", lambda s: s > 0)
         assert fail_count == 0
-        assert samples == []
+        assert not samples
 
     def test_custom_check_with_nulls_treated_as_failure(self) -> None:
         series = pd.Series([1, None, 3])

--- a/tests/test_hypothesis_pilot.py
+++ b/tests/test_hypothesis_pilot.py
@@ -102,7 +102,7 @@ class TestCheckBoundaryInvariants:
         ]:
             fail_count, samples = apply_check(empty_series, check_name, check_value)
             assert fail_count == 0
-            assert samples == []
+            assert not samples
 
     @given(
         n_failures=st.integers(min_value=10, max_value=100),

--- a/tests/validators/test_builder.py
+++ b/tests/validators/test_builder.py
@@ -34,7 +34,7 @@ class TestBuildValidationPipeline:
             df_columns=["a", "b"],
         )
 
-        assert len(pipeline) == 0
+        assert not pipeline
 
     def test_adds_shape_validator_for_min_rows(self) -> None:
         pipeline = build_validation_pipeline(

--- a/tests/validators/test_columns.py
+++ b/tests/validators/test_columns.py
@@ -16,7 +16,7 @@ class TestColumnsExistValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1], "b": [2]}))
         validator = ColumnsExistValidator(missing_columns=[], available_columns=["a", "b"])
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_fails_when_columns_missing(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
@@ -43,7 +43,7 @@ class TestDtypeValidator:
         expected_dtype = ctx.get_dtype("a")
         validator = DtypeValidator({"a": expected_dtype})
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_fails_when_dtype_mismatch(self) -> None:
         df = pd.DataFrame({"a": [1, 2, 3]})
@@ -58,7 +58,7 @@ class TestDtypeValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
         validator = DtypeValidator({"nonexistent": "int64"})
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
 
 class TestNullableValidator:
@@ -66,7 +66,7 @@ class TestNullableValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1, 2, 3]}))
         validator = NullableValidator(["a"])
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_fails_when_nulls_present(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1, None, 3]}))
@@ -88,7 +88,7 @@ class TestNullableValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
         validator = NullableValidator(["nonexistent"])
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_multiple_columns(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": [None], "b": [None]}))
@@ -106,7 +106,7 @@ class TestStrictModeValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1], "b": [2]}))
         validator = StrictModeValidator({"a", "b"})
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_fails_when_extra_columns(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1], "b": [2], "c": [3]}))
@@ -121,4 +121,4 @@ class TestStrictModeValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
         validator = StrictModeValidator({"a", "b", "c"})
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)

--- a/tests/validators/test_missing_coverage.py
+++ b/tests/validators/test_missing_coverage.py
@@ -9,16 +9,16 @@ from daffy.validators.uniqueness import UniqueValidator
 def test_nullable_validator_missing_column() -> None:
     ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
     val = NullableValidator(["missing"])
-    assert val.validate(ctx) == []
+    assert not val.validate(ctx)
 
 
 def test_unique_validator_missing_column() -> None:
     ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
     val = UniqueValidator(["missing"])
-    assert val.validate(ctx) == []
+    assert not val.validate(ctx)
 
 
 def test_checks_validator_missing_column() -> None:
     ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
     val = ChecksValidator({"missing": {"gt": 0}})
-    assert val.validate(ctx) == []
+    assert not val.validate(ctx)

--- a/tests/validators/test_pipeline.py
+++ b/tests/validators/test_pipeline.py
@@ -84,7 +84,7 @@ class TestValidationPipeline:
 
     def test_len_returns_validator_count(self) -> None:
         pipeline = ValidationPipeline()
-        assert len(pipeline) == 0
+        assert not pipeline
 
         pipeline.add(AlwaysPassValidator())
         assert len(pipeline) == 1

--- a/tests/validators/test_shape.py
+++ b/tests/validators/test_shape.py
@@ -11,13 +11,13 @@ class TestShapeValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1, 2, 3]}))
         validator = ShapeValidator()
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_passes_min_rows(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1, 2, 3]}))
         validator = ShapeValidator(min_rows=2)
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_fails_min_rows(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
@@ -31,7 +31,7 @@ class TestShapeValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1, 2, 3]}))
         validator = ShapeValidator(max_rows=10)
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_fails_max_rows(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1, 2, 3, 4, 5]}))
@@ -45,7 +45,7 @@ class TestShapeValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1, 2, 3]}))
         validator = ShapeValidator(exact_rows=3)
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_fails_exact_rows(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": [1, 2]}))
@@ -59,7 +59,7 @@ class TestShapeValidator:
         ctx = ValidationContext(df=pd.DataFrame({"a": []}))
         validator = ShapeValidator(allow_empty=True)
 
-        assert validator.validate(ctx) == []
+        assert not validator.validate(ctx)
 
     def test_fails_allow_empty_false(self) -> None:
         ctx = ValidationContext(df=pd.DataFrame({"a": []}))

--- a/tests/validators/test_spec_parser.py
+++ b/tests/validators/test_spec_parser.py
@@ -9,17 +9,17 @@ class TestParseColumnSpec:
     def test_none_returns_empty_spec(self) -> None:
         result = parse_column_spec(None)
 
-        assert result.required_columns == []
-        assert result.dtype_constraints == {}
-        assert result.non_nullable_columns == []
-        assert result.unique_columns == []
-        assert result.checks_by_column == {}
+        assert not result.required_columns
+        assert not result.dtype_constraints
+        assert not result.non_nullable_columns
+        assert not result.unique_columns
+        assert not result.checks_by_column
 
     def test_list_creates_required_columns(self) -> None:
         result = parse_column_spec(["a", "b", "c"])
 
         assert result.required_columns == ["a", "b", "c"]
-        assert result.dtype_constraints == {}
+        assert not result.dtype_constraints
 
     def test_dict_with_dtype_shorthand(self) -> None:
         result = parse_column_spec({"a": "int64", "b": "float64"})
@@ -42,7 +42,7 @@ class TestParseColumnSpec:
     def test_dict_with_nullable_true_not_added(self) -> None:
         result = parse_column_spec({"a": {"nullable": True}})
 
-        assert result.non_nullable_columns == []
+        assert not result.non_nullable_columns
 
     def test_dict_with_unique_true(self) -> None:
         result = parse_column_spec({"a": {"unique": True}})
@@ -53,7 +53,7 @@ class TestParseColumnSpec:
     def test_dict_with_unique_false_not_added(self) -> None:
         result = parse_column_spec({"a": {"unique": False}})
 
-        assert result.unique_columns == []
+        assert not result.unique_columns
 
     def test_dict_with_checks(self) -> None:
         result = parse_column_spec({"a": {"checks": {"gt": 0, "lt": 100}}})
@@ -77,7 +77,7 @@ class TestParseColumnSpec:
     def test_dict_with_required_false(self) -> None:
         result = parse_column_spec({"a": {"dtype": "int64", "required": False}})
 
-        assert result.required_columns == []
+        assert not result.required_columns
         assert result.optional_columns == ["a"]
         assert result.dtype_constraints == {"a": "int64"}
 


### PR DESCRIPTION
## Summary

Our analysis found **~39 format/import tidy opportunities** and about **271 refactoring opportunities** across the reviewed scope. Security scans were clean; duplication is low; maintainability index and cyclomatic complexity look good in the scanned scope; about 271 structural refactor suggestions remain (mostly test helpers and decorator complexity).

This pull request is a **sample** of those findings — **11 files, ~60 focused line changes** — not a full format pass or refactor cleanup.

Hotspots and improvement notes below are scoped to **Python (`*.py`)** source.

## What you are doing right

- No secrets detected in scope (gitleaks).
- Code duplication looks clean — jscpd reported no meaningful clones above the configured threshold.
- Maintainability index and cyclomatic complexity look good for core validation modules (radon).
- Strong test coverage and CI matrix (Python 3.10–3.14, optional-dependency isolation scenarios).
- Clear decorator-first API with thoughtful optional-dependency design.

## What you could improve
- **Lint / style:** Wrap long multi-import lines in `daffy/validators/__init__.py` for readability. *(included in example PR)*

## Changes

- `tests/test_config.py` — use `Path.open()` for temporary `pyproject.toml` fixtures (10 call sites).
- `tests/test_checks.py`, `tests/test_custom_checks.py`, `tests/test_hypothesis_pilot.py` — simplify empty-list assertions.
- `tests/validators/test_columns.py`, `tests/validators/test_shape.py`, `tests/validators/test_spec_parser.py`, `tests/validators/test_missing_coverage.py` — simplify empty-list / empty-result assertions.
- `tests/validators/test_builder.py`, `tests/validators/test_pipeline.py` — use truthiness for empty `ValidationPipeline` checks.
- `daffy/validators/__init__.py` — format long import from `validators.columns`.
