### PR TITLE
Daffy 3.0.0: backend-native nulls, regex without hidden anchors, ~3x faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 3.0.0
+
+This release removes two pieces of hidden magic and makes validation roughly three times cheaper.
+All three behavior changes were found by mutation-testing the suite: each was behaviour nothing
+pinned and nothing documented.
+
+**Migrating:** anchor any unanchored regex you relied on (`r"\d+"` → `r"^\d+"`, `r/Price_\d+/` →
+`r/^Price_\d+/`), and add `nullable=False` to columns where you were relying on a null failing a
+value check.
 
 ### Changed
 
@@ -15,9 +23,17 @@ All notable changes to this project will be documented in this file.
 - Parameterised dtypes can now be declared by base name: `{"created_at": "datetime"}` matches any time unit or time zone, and the same applies to `duration`, `list`, `struct` and `enum`. Previously the only accepted spelling was the full internal repr (`"datetime(time_unit='ns', time_zone=none)"`). Spelling the parameters out still constrains them.
 - String checks (`str_regex`, `str_startswith`, `str_endswith`, `str_contains`) no longer raise `TypeError: bad operand type for unary ~` on Pandas object-dtype columns containing nulls
 
+### Performance
+
+- Per-call validation overhead cut by roughly 3x: `@df_in(columns=...)` on a 100-row Pandas frame went from ~212µs to ~66µs, `@df_in(min_rows=...)` from ~216µs to ~69µs. Configuration is now resolved in one lookup per call instead of one per setting, the DataFrame is converted to Narwhals once instead of three times, and column dtypes are only read when a dtype constraint needs them.
+
+### Removed
+
+- `daffy.config.get_strict`, `get_lazy`, `get_strict_specs` and `get_allow_empty` — internal helpers superseded by `resolve_decorator_settings`. They were never exported from the `daffy` package.
+
 ### Documentation
 
-- Documented `str_regex` anchoring (the caller's pattern is applied as written) and that nulls count as failures for every check
+- Documented null handling per backend, `str_regex` anchoring, how to declare parameterised dtypes, and that regex syntax support depends on the backend's own engine
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Behavior change:** value checks no longer force nulls to count as failures. Daffy used to rewrite null comparison results into violations; it now leaves each backend's semantics intact, so on Polars, PyArrow and Pandas nullable dtypes a comparison against null is "unknown" and is not reported. Pandas float `NaN` compares as `False` and still fails. Use `nullable=False` or the `notnull` check to constrain nulls explicitly — those behave identically on every backend.
 - **Behavior change:** `str_regex` now applies the pattern as written instead of silently anchoring it at the start of the value. `{"str_regex": r"\d+"}` used to mean "starts with digits" and now means "contains digits"; add the anchor yourself (`r"^\d+"`, or `r"^\d+$"` for a full match) to keep the old meaning. Patterns that were already anchored are unaffected.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- String checks (`str_regex`, `str_startswith`, `str_endswith`, `str_contains`) no longer raise `TypeError: bad operand type for unary ~` on Pandas object-dtype columns containing nulls; the null is reported as a check failure like on every other backend
+- Parameterised dtypes can now be declared by base name: `{"created_at": "datetime"}` matches any time unit or time zone, and the same applies to `duration`, `list`, `struct` and `enum`. Previously the only accepted spelling was the full internal repr (`"datetime(time_unit='ns', time_zone=none)"`). Spelling the parameters out still constrains them.
+- String checks (`str_regex`, `str_startswith`, `str_endswith`, `str_contains`) no longer raise `TypeError: bad operand type for unary ~` on Pandas object-dtype columns containing nulls
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- **Behavior change:** `str_regex` now applies the pattern as written instead of silently anchoring it at the start of the value. `{"str_regex": r"\d+"}` used to mean "starts with digits" and now means "contains digits"; add the anchor yourself (`r"^\d+"`, or `r"^\d+$"` for a full match) to keep the old meaning. Patterns that were already anchored are unaffected.
+
 ### Fixed
 
 - String checks (`str_regex`, `str_startswith`, `str_endswith`, `str_contains`) no longer raise `TypeError: bad operand type for unary ~` on Pandas object-dtype columns containing nulls; the null is reported as a check failure like on every other backend
+
+### Documentation
+
+- Documented `str_regex` anchoring (the caller's pattern is applied as written) and that nulls count as failures for every check
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - **Behavior change:** value checks no longer force nulls to count as failures. Daffy used to rewrite null comparison results into violations; it now leaves each backend's semantics intact, so on Polars, PyArrow and Pandas nullable dtypes a comparison against null is "unknown" and is not reported. Pandas float `NaN` compares as `False` and still fails. Use `nullable=False` or the `notnull` check to constrain nulls explicitly — those behave identically on every backend.
+- **Behavior change:** regex column patterns (`"r/pattern/"`) now match anywhere in the column name instead of only at the start, so `r/Price_\d+/` also matches `Total_Price_1`. Anchor the pattern yourself (`r/^Price_\d+/`) to keep the old meaning. This makes column patterns and `str_regex` follow the same rule.
 - **Behavior change:** `str_regex` now applies the pattern as written instead of silently anchoring it at the start of the value. `{"str_regex": r"\d+"}` used to mean "starts with digits" and now means "contains digits"; add the anchor yourself (`r"^\d+"`, or `r"^\d+$"` for a full match) to keep the old meaning. Patterns that were already anchored are unaffected.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 ## 3.0.0
 
 This release removes two pieces of hidden magic and makes validation roughly three times cheaper.
-All three behavior changes were found by mutation-testing the suite: each was behaviour nothing
-pinned and nothing documented.
+Mutation testing found all three behavior changes: the test suite asserted none of them, and the
+documentation described none of them.
 
 **Migrating:** anchor any unanchored regex you relied on (`r"\d+"` → `r"^\d+"`, `r/Price_\d+/` →
 `r/^Price_\d+/`), and add `nullable=False` to columns where you were relying on a null failing a
@@ -25,7 +25,7 @@ value check.
 
 ### Performance
 
-- Per-call validation overhead cut by roughly 3x: `@df_in(columns=...)` on a 100-row Pandas frame went from ~212µs to ~66µs, `@df_in(min_rows=...)` from ~216µs to ~69µs. Configuration is now resolved in one lookup per call instead of one per setting, the DataFrame is converted to Narwhals once instead of three times, and column dtypes are only read when a dtype constraint needs them.
+- Per-call validation overhead cut by roughly 5x: `@df_in(columns=...)` on a 100-row Pandas frame went from ~212µs to ~41µs, `@df_in(min_rows=...)` from ~216µs to ~44µs. Configuration is now resolved in one lookup per call instead of one per setting, the DataFrame is converted to Narwhals once instead of three times, and column dtypes are only read when a dtype constraint needs them.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- String checks (`str_regex`, `str_startswith`, `str_endswith`, `str_contains`) no longer raise `TypeError: bad operand type for unary ~` on Pandas object-dtype columns containing nulls; the null is reported as a check failure like on every other backend
+
 ## 2.8.0
 
 ### Changed

--- a/daffy/checks.py
+++ b/daffy/checks.py
@@ -2,6 +2,10 @@
 
 All check functions return a mask where True indicates a FAILING value.
 This convention allows consistent handling: count failures and sample them.
+
+Null handling follows the backend rather than being normalised here: a comparison
+against a null yields "unknown" on backends with three-valued logic, and unknown is
+not a violation. Use `nullable=False` or the `notnull` check to constrain nulls.
 """
 
 from __future__ import annotations
@@ -37,17 +41,19 @@ def _nw_series(series: Any) -> nw.Series[Any]:
 
 
 def _failing_mask(valid_mask: nw.Series[Any]) -> nw.Series[Any]:
-    """Turn a validity mask into a failure mask, counting nulls as failures.
+    """Turn a validity mask into a failure mask, leaving each backend's null semantics intact.
 
-    Filling nulls before inverting keeps pandas object-dtype masks (which hold `None`
-    rather than a null-aware boolean) from reaching `~`, where they raise a TypeError.
+    A null comparison result means "unknown", not "failed", so it is not counted as a
+    violation. Resolving it before inverting also keeps pandas object-dtype masks (which
+    hold `None` rather than a null-aware boolean) from reaching `~`, where they raise a
+    TypeError.
     """
-    return ~valid_mask.fill_null(False).cast(nw.Boolean())
+    return ~valid_mask.fill_null(True).cast(nw.Boolean())
 
 
 def _evaluate_mask(nws: nw.Series[Any], fail_mask: nw.Series[Any], max_samples: int) -> tuple[int, list[Any]]:
     """Count failures and sample failing values from a boolean mask (True = failing)."""
-    nw_mask = fail_mask.fill_null(True)
+    nw_mask = fail_mask.fill_null(False)
     fail_count = int(nw_mask.sum())
     if fail_count == 0:
         return 0, []

--- a/daffy/checks.py
+++ b/daffy/checks.py
@@ -36,6 +36,15 @@ def _nw_series(series: Any) -> nw.Series[Any]:
     return nw.from_native(series, series_only=True)
 
 
+def _failing_mask(valid_mask: nw.Series[Any]) -> nw.Series[Any]:
+    """Turn a validity mask into a failure mask, counting nulls as failures.
+
+    Filling nulls before inverting keeps pandas object-dtype masks (which hold `None`
+    rather than a null-aware boolean) from reaching `~`, where they raise a TypeError.
+    """
+    return ~valid_mask.fill_null(False).cast(nw.Boolean())
+
+
 def _evaluate_mask(nws: nw.Series[Any], fail_mask: nw.Series[Any], max_samples: int) -> tuple[int, list[Any]]:
     """Count failures and sample failing values from a boolean mask (True = failing)."""
     nw_mask = fail_mask.fill_null(True)
@@ -78,26 +87,28 @@ def apply_check(series_or_nws: Any, check_name: str, check_value: Any, max_sampl
             ) from None
 
         # Custom checks return True for VALID values, but we need True for INVALID.
-        return _evaluate_mask(nws, ~nw_result, max_samples)
+        return _evaluate_mask(nws, _failing_mask(nw_result), max_samples)
 
     # Built-in checks: each lambda returns a mask where True = FAILING value.
-    # The ~ operator inverts comparison results (e.g., ~(x > 0) means "not greater than 0").
+    # _failing_mask inverts a validity mask (e.g. x > 0) into "not greater than 0".
     check_masks = {
-        "gt": lambda: ~(nws > check_value),
-        "ge": lambda: ~(nws >= check_value),
-        "lt": lambda: ~(nws < check_value),
-        "le": lambda: ~(nws <= check_value),
-        "between": lambda: ~((nws >= check_value[0]) & (nws <= check_value[1])),
+        "gt": lambda: _failing_mask(nws > check_value),
+        "ge": lambda: _failing_mask(nws >= check_value),
+        "lt": lambda: _failing_mask(nws < check_value),
+        "le": lambda: _failing_mask(nws <= check_value),
+        "between": lambda: _failing_mask((nws >= check_value[0]) & (nws <= check_value[1])),
         "eq": lambda: nws != check_value,
         "ne": lambda: nws == check_value,
-        "isin": lambda: ~nws.is_in(check_value),
+        "isin": lambda: _failing_mask(nws.is_in(check_value)),
         "notin": lambda: nws.is_in(check_value),
         "notnull": lambda: nws.is_null(),  # noqa: PLW0108
-        "str_regex": lambda: ~nws.str.contains(f"^(?:{check_value})"),
-        "str_startswith": lambda: ~nws.str.starts_with(check_value),
-        "str_endswith": lambda: ~nws.str.ends_with(check_value),
-        "str_contains": lambda: ~nws.str.contains(check_value, literal=True),
-        "str_length": lambda: ~((nws.str.len_chars() >= check_value[0]) & (nws.str.len_chars() <= check_value[1])),
+        "str_regex": lambda: _failing_mask(nws.str.contains(f"^(?:{check_value})")),
+        "str_startswith": lambda: _failing_mask(nws.str.starts_with(check_value)),
+        "str_endswith": lambda: _failing_mask(nws.str.ends_with(check_value)),
+        "str_contains": lambda: _failing_mask(nws.str.contains(check_value, literal=True)),
+        "str_length": lambda: _failing_mask(
+            (nws.str.len_chars() >= check_value[0]) & (nws.str.len_chars() <= check_value[1])
+        ),
     }
 
     if check_name not in check_masks:

--- a/daffy/checks.py
+++ b/daffy/checks.py
@@ -102,7 +102,7 @@ def apply_check(series_or_nws: Any, check_name: str, check_value: Any, max_sampl
         "isin": lambda: _failing_mask(nws.is_in(check_value)),
         "notin": lambda: nws.is_in(check_value),
         "notnull": lambda: nws.is_null(),  # noqa: PLW0108
-        "str_regex": lambda: _failing_mask(nws.str.contains(f"^(?:{check_value})")),
+        "str_regex": lambda: _failing_mask(nws.str.contains(check_value)),
         "str_startswith": lambda: _failing_mask(nws.str.starts_with(check_value)),
         "str_endswith": lambda: _failing_mask(nws.str.ends_with(check_value)),
         "str_contains": lambda: _failing_mask(nws.str.contains(check_value, literal=True)),

--- a/daffy/config.py
+++ b/daffy/config.py
@@ -123,62 +123,12 @@ def resolve_decorator_settings(strict: bool | None, lazy: bool | None, allow_emp
     )
 
 
-def _get_bool_config(param: bool | None, key: str) -> bool:
-    """Return param if provided, otherwise config value."""
-    if param is not None:
-        return param
-    return bool(get_config()[key])
-
-
 def _get_int_config(param: int | None, key: str, min_value: int = 1) -> int:
     """Return param if provided, otherwise config value. Validates minimum."""
     value = param if param is not None else int(get_config()[key])
     if value < min_value:
         raise ValueError(f"{key} must be >= {min_value}, got {value}")
     return value
-
-
-def get_strict(strict_param: bool | None = None) -> bool:
-    """Get the strict mode setting, with explicit parameter taking precedence over configuration.
-
-    Args:
-        strict_param: Explicitly provided strict parameter value, or None to use config
-
-    Returns:
-        bool: The effective strict mode setting
-
-    """
-    return _get_bool_config(strict_param, _KEY_STRICT)
-
-
-def get_lazy(lazy_param: bool | None = None) -> bool:
-    """Get the lazy mode setting, with explicit parameter taking precedence over configuration.
-
-    When lazy=True, validation collects all errors before raising instead of stopping at the first.
-
-    Args:
-        lazy_param: Explicitly provided lazy parameter value, or None to use config
-
-    Returns:
-        bool: The effective lazy mode setting
-
-    """
-    return _get_bool_config(lazy_param, _KEY_LAZY)
-
-
-def get_strict_specs(strict_specs_param: bool | None = None) -> bool:
-    """Get strict_specs setting, with explicit parameter taking precedence over configuration.
-
-    When strict_specs=True, invalid column spec keys/types raise errors instead of being ignored.
-
-    Args:
-        strict_specs_param: Explicitly provided strict_specs value, or None to use config
-
-    Returns:
-        bool: The effective strict_specs setting
-
-    """
-    return _get_bool_config(strict_specs_param, _KEY_STRICT_SPECS)
 
 
 def get_row_validation_max_errors() -> int:
@@ -189,18 +139,3 @@ def get_row_validation_max_errors() -> int:
 def get_checks_max_samples(max_samples: int | None = None) -> int:
     """Get max_samples setting for value checks."""
     return _get_int_config(max_samples, _KEY_CHECKS_MAX_SAMPLES)
-
-
-def get_allow_empty(allow_empty_param: bool | None = None) -> bool:
-    """Get the allow_empty setting, with explicit parameter taking precedence over configuration.
-
-    When allow_empty=False, empty DataFrames (0 rows) will raise an error.
-
-    Args:
-        allow_empty_param: Explicitly provided allow_empty parameter value, or None to use config
-
-    Returns:
-        bool: The effective allow_empty setting
-
-    """
-    return _get_bool_config(allow_empty_param, _KEY_ALLOW_EMPTY)

--- a/daffy/config.py
+++ b/daffy/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any
+from typing import Any, NamedTuple
 
 import tomli
 
@@ -85,15 +85,42 @@ def _get_config_for_cwd(cwd: str) -> MappingProxyType[str, Any]:
 def get_config() -> MappingProxyType[str, Any]:
     """Get the daffy configuration, cached by current working directory.
 
+    Keyed on the unresolved working directory: resolving symlinks costs a syscall on
+    every validated call, and `find_config_file` resolves the path anyway on a cache
+    miss. Two aliases of the same directory get two cache entries with equal contents.
+
     Returns an immutable view of the configuration to prevent accidental modification.
     """
-    cwd = str(Path.cwd().resolve())
-    return _get_config_for_cwd(cwd)
+    return _get_config_for_cwd(str(Path.cwd()))
 
 
 def clear_config_cache() -> None:
     """Clear the configuration cache. Primarily for testing."""
     _get_config_for_cwd.cache_clear()
+
+
+class DecoratorSettings(NamedTuple):
+    """Settings resolved for one validation run."""
+
+    strict: bool
+    strict_specs: bool
+    lazy: bool
+    allow_empty: bool
+
+
+def resolve_decorator_settings(strict: bool | None, lazy: bool | None, allow_empty: bool | None) -> DecoratorSettings:
+    """Resolve the decorator settings with a single configuration lookup.
+
+    Reading the config resolves the current working directory, so doing it once per
+    validation instead of once per setting keeps that cost off the hot path.
+    """
+    config = get_config()
+    return DecoratorSettings(
+        strict=strict if strict is not None else bool(config[_KEY_STRICT]),
+        strict_specs=bool(config[_KEY_STRICT_SPECS]),
+        lazy=lazy if lazy is not None else bool(config[_KEY_LAZY]),
+        allow_empty=allow_empty if allow_empty is not None else bool(config[_KEY_ALLOW_EMPTY]),
+    )
 
 
 def _get_bool_config(param: bool | None, key: str) -> bool:

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from daffy.dataframe_types import IntoDataFrameT
     from daffy.validation import ColumnsDef
 
-from daffy.config import get_allow_empty, get_lazy, get_strict, get_strict_specs
+from daffy.config import resolve_decorator_settings
 from daffy.utils import (
     ParameterResolver,
     assert_is_dataframe,
@@ -78,6 +78,7 @@ def _run_validations(
     allow_empty: bool | None,
     param_name: str | None,
     is_return_value: bool,
+    nw_df: Any = None,
 ) -> None:
     """Run all validations on a DataFrame using the validation pipeline."""
     ctx = ValidationContext(
@@ -85,19 +86,21 @@ def _run_validations(
         func_name=func_name,
         param_name=param_name,
         is_return_value=is_return_value,
+        nw_df=nw_df,
     )
 
+    settings = resolve_decorator_settings(strict, lazy, allow_empty)
     pipeline = build_validation_pipeline(
         columns=columns,
-        strict=get_strict(strict),
-        strict_specs=get_strict_specs(),
-        lazy=get_lazy(lazy),
+        strict=settings.strict,
+        strict_specs=settings.strict_specs,
+        lazy=settings.lazy,
         composite_unique=composite_unique,
         row_validator=row_validator,
         min_rows=min_rows,
         max_rows=max_rows,
         exact_rows=exact_rows,
-        allow_empty=get_allow_empty(allow_empty),
+        allow_empty=settings.allow_empty,
         df_columns=list(ctx.columns),
     )
     pipeline.run(ctx)
@@ -153,7 +156,7 @@ def df_out(
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> IntoDataFrameT:
             result = func(*args, **kwargs)
-            assert_is_dataframe(result, "return type")
+            nw_df = assert_is_dataframe(result, "return type")
             _run_validations(
                 result,
                 getattr(func, "__name__", "<unknown>"),
@@ -168,6 +171,7 @@ def df_out(
                 allow_empty,
                 param_name=None,
                 is_return_value=True,
+                nw_df=nw_df,
             )
             return result
 
@@ -271,7 +275,7 @@ def df_in(
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> InReturnT:
             df, param_name = resolver.resolve(name, *args, **kwargs)
-            assert_is_dataframe(df, "parameter type")
+            nw_df = assert_is_dataframe(df, "parameter type")
             _run_validations(
                 df,
                 getattr(func, "__name__", "<unknown>"),
@@ -286,6 +290,7 @@ def df_in(
                 allow_empty,
                 param_name=param_name,
                 is_return_value=False,
+                nw_df=nw_df,
             )
             return func(*args, **kwargs)
 

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -274,8 +274,8 @@ def df_in(
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> InReturnT:
-            df, param_name = resolver.resolve(name, *args, **kwargs)
-            nw_df = assert_is_dataframe(df, "parameter type")
+            df, param_name, resolved_nw_df = resolver.resolve(name, *args, **kwargs)
+            nw_df = assert_is_dataframe(df, "parameter type", resolved_nw_df)
             _run_validations(
                 df,
                 getattr(func, "__name__", "<unknown>"),
@@ -321,7 +321,7 @@ def df_log(
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> LogReturnT:
             func_name = getattr(func, "__name__", "<unknown>")
-            df, _ = resolver.resolve(None, *args, **kwargs)
+            df, _, _ = resolver.resolve(None, *args, **kwargs)
             log_dataframe_input(level, func_name, df, include_dtypes)
             result = func(*args, **kwargs)
             log_dataframe_output(level, func_name, result, include_dtypes)

--- a/daffy/narwhals_compat.py
+++ b/daffy/narwhals_compat.py
@@ -7,10 +7,14 @@ from typing import Any
 import narwhals as nw
 
 
+def to_nw_dataframe(obj: Any) -> Any | None:
+    """Convert to a Narwhals DataFrame, or return None if the object is not one."""
+    try:
+        return nw.from_native(obj, eager_only=True)
+    except TypeError:
+        return None
+
+
 def is_supported_dataframe(obj: Any) -> bool:
     """Check if object is a supported eager DataFrame type."""
-    try:
-        nw.from_native(obj, eager_only=True)
-    except TypeError:
-        return False
-    return True
+    return to_nw_dataframe(obj) is not None

--- a/daffy/patterns.py
+++ b/daffy/patterns.py
@@ -43,6 +43,10 @@ def compile_regex_pattern(pattern_string: str) -> RegexColumnDef:
 
 
 def match_column_with_regex(column_pattern: RegexColumnDef, df_columns: list[str]) -> list[str]:
-    """Find DataFrame columns matching a regex pattern."""
+    """Find DataFrame columns matching a regex pattern.
+
+    The pattern is applied as written - it matches anywhere in the column name unless
+    anchored by the caller, the same way `str_regex` treats value patterns.
+    """
     _, pattern = column_pattern
-    return [col for col in df_columns if pattern.match(col)]
+    return [col for col in df_columns if pattern.search(col)]

--- a/daffy/utils.py
+++ b/daffy/utils.py
@@ -15,12 +15,13 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def assert_is_dataframe(obj: Any, context: str) -> Any:
+def assert_is_dataframe(obj: Any, context: str, nw_df: Any = None) -> Any:
     """Verify that an object is a supported DataFrame (Pandas, Polars, Modin, or PyArrow).
 
     Args:
         obj: Object to validate
         context: Context string for the error message (e.g., "parameter type", "return type")
+        nw_df: Narwhals view of obj when the caller already has one, to skip re-converting
 
     Returns:
         The Narwhals view of the DataFrame, so callers do not convert it a second time.
@@ -29,7 +30,8 @@ def assert_is_dataframe(obj: Any, context: str) -> Any:
         AssertionError: If obj is not a DataFrame
 
     """
-    nw_df = to_nw_dataframe(obj)
+    if nw_df is None:
+        nw_df = to_nw_dataframe(obj)
     if nw_df is None:
         libs_str = " or ".join(get_available_library_names())
         raise AssertionError(f"Wrong {context}. Expected {libs_str} DataFrame, got {type(obj).__name__} instead.")
@@ -51,22 +53,29 @@ class ParameterResolver:
         self.var_pos_name = next((p.name for p in self.params if p.kind is inspect.Parameter.VAR_POSITIONAL), None)
         self.var_kw_name = next((p.name for p in self.params if p.kind is inspect.Parameter.VAR_KEYWORD), None)
 
-    def resolve(self, name: str | None, *args: Any, **kwargs: Any) -> tuple[Any, str | None]:  # noqa: C901, PLR0911, PLR0912
-        """Extract a parameter value and its name from function arguments."""
+    def resolve(self, name: str | None, *args: Any, **kwargs: Any) -> tuple[Any, str | None, Any]:  # noqa: C901, PLR0911, PLR0912
+        """Extract a parameter value and its name from function arguments.
+
+        Returns (value, parameter name, Narwhals view). The Narwhals view is None unless
+        searching for the DataFrame already produced one, in which case callers reuse it
+        instead of converting the same frame again.
+        """
         if not name:
             # 1. Search positional arguments
             for i, arg in enumerate(args):
-                if is_supported_dataframe(arg):
+                nw_df = to_nw_dataframe(arg)
+                if nw_df is not None:
                     if i < len(self.param_names):
-                        return arg, self.param_names[i]
-                    return arg, self.var_pos_name
+                        return arg, self.param_names[i], nw_df
+                    return arg, self.var_pos_name, nw_df
 
             # 2. Search keyword arguments
             for kw_name, kw_val in kwargs.items():
-                if is_supported_dataframe(kw_val):
+                nw_df = to_nw_dataframe(kw_val)
+                if nw_df is not None:
                     # If it's explicitly in the signature, return that name.
                     # Otherwise, if it's passed as kwargs but VAR_KEYWORD exists, return kw_name.
-                    return kw_val, kw_name
+                    return kw_val, kw_name, nw_df
 
             # 3. Fallback to first argument if no dataframe found
             value = args[0] if args else next(iter(kwargs.values()), None)
@@ -74,10 +83,10 @@ class ParameterResolver:
                 param_name = self.param_names[0] if self.param_names else None
             else:
                 param_name = next(iter(kwargs.keys()), None)
-            return value, param_name
+            return value, param_name, None
 
         if name in kwargs:
-            return kwargs[name], name
+            return kwargs[name], name, None
 
         try:
             parameter_location = self.param_names.index(name)
@@ -91,18 +100,18 @@ class ParameterResolver:
 
         if kind == inspect.Parameter.KEYWORD_ONLY:
             if default is not inspect.Parameter.empty:
-                return default, name
+                return default, name, None
             raise ValueError(f"Required keyword-only parameter '{name}' not provided in arguments.")
 
         if parameter_location >= len(args):
             if default is not inspect.Parameter.empty:
-                return default, name
+                return default, name, None
             raise ValueError(
                 f"Parameter '{name}' not found in function arguments. "
                 f"Expected at position {parameter_location}, but only {len(args)} positional arguments provided."
             )
 
-        return args[parameter_location], name
+        return args[parameter_location], name, None
 
 
 def describe_dataframe(df: Any, include_dtypes: bool = False) -> str:

--- a/daffy/utils.py
+++ b/daffy/utils.py
@@ -9,26 +9,31 @@ from typing import TYPE_CHECKING, Any
 import narwhals as nw
 
 from daffy.dataframe_types import get_available_library_names
-from daffy.narwhals_compat import is_supported_dataframe
+from daffy.narwhals_compat import is_supported_dataframe, to_nw_dataframe
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def assert_is_dataframe(obj: Any, context: str) -> None:
+def assert_is_dataframe(obj: Any, context: str) -> Any:
     """Verify that an object is a supported DataFrame (Pandas, Polars, Modin, or PyArrow).
 
     Args:
         obj: Object to validate
         context: Context string for the error message (e.g., "parameter type", "return type")
 
+    Returns:
+        The Narwhals view of the DataFrame, so callers do not convert it a second time.
+
     Raises:
         AssertionError: If obj is not a DataFrame
 
     """
-    if not is_supported_dataframe(obj):
+    nw_df = to_nw_dataframe(obj)
+    if nw_df is None:
         libs_str = " or ".join(get_available_library_names())
         raise AssertionError(f"Wrong {context}. Expected {libs_str} DataFrame, got {type(obj).__name__} instead.")
+    return nw_df
 
 
 class ParameterResolver:

--- a/daffy/validators/columns.py
+++ b/daffy/validators/columns.py
@@ -36,6 +36,27 @@ def _normalize_dtype(dtype: str) -> str:
     return _DTYPE_ALIASES.get(dtype_lower, dtype_lower)
 
 
+def _base_dtype(dtype: str) -> str:
+    """Strip parameters from a dtype, e.g. "datetime(time_unit='ns', ...)" -> "datetime"."""
+    return dtype.split("(", 1)[0]
+
+
+def _dtype_matches(actual: Any, expected: Any) -> bool:
+    """Compare an actual dtype against an expected one.
+
+    Parameterised dtypes (Datetime, Duration, List, Struct, Enum) render with their
+    parameters, so an unparameterised expectation like "datetime" is compared against
+    the base name only. Spell the parameters out to constrain them.
+    """
+    actual_norm = _normalize_dtype(actual)
+    expected_norm = _normalize_dtype(expected)
+    if actual_norm == expected_norm:
+        return True
+    if "(" in expected_norm:
+        return False
+    return _base_dtype(actual_norm) == expected_norm
+
+
 @dataclass
 class DtypeValidator:
     expected: dict[str, Any]
@@ -45,7 +66,7 @@ class DtypeValidator:
         for col, expected_dtype in self.expected.items():
             if ctx.has_column(col):
                 actual = ctx.get_dtype(col)
-                if _normalize_dtype(actual) != _normalize_dtype(expected_dtype):
+                if not _dtype_matches(actual, expected_dtype):
                     actual_str = str(actual).lower()
                     msg = f"Column {col}{ctx.param_info} has wrong dtype. Was {actual_str}, expected {expected_dtype}"
                     errors.append(msg)

--- a/daffy/validators/context.py
+++ b/daffy/validators/context.py
@@ -16,20 +16,27 @@ class ValidationContext:
     func_name: str = ""
     param_name: str | None = None
     is_return_value: bool = False
+    nw_df: Any = field(default=None, repr=False)
 
-    nw_df: Any = field(init=False, repr=False)
     columns: tuple[str, ...] = field(init=False)
     column_set: frozenset[str] = field(init=False)
     row_count: int = field(init=False)
-    schema: dict[str, Any] = field(init=False)
+    _schema: dict[str, Any] | None = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        nw_df = nw.from_native(self.df, eager_only=True)
+        nw_df = self.nw_df if self.nw_df is not None else nw.from_native(self.df, eager_only=True)
         object.__setattr__(self, "nw_df", nw_df)
         object.__setattr__(self, "columns", tuple(nw_df.columns))
         object.__setattr__(self, "column_set", frozenset(nw_df.columns))
         object.__setattr__(self, "row_count", nw_df.shape[0])
-        object.__setattr__(self, "schema", dict(nw_df.schema))
+        object.__setattr__(self, "_schema", None)
+
+    @property
+    def schema(self) -> dict[str, Any]:
+        """Column dtypes, resolved on first use - only dtype validation needs them."""
+        if self._schema is None:
+            object.__setattr__(self, "_schema", dict(self.nw_df.schema))
+        return self._schema  # type: ignore[return-value]
 
     @property
     def param_info(self) -> str:

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -310,6 +310,12 @@ def process_data(df):
 | `str_contains`   | string     | String contains substring  | `{"str_contains": "@"}`      |
 | `str_length`     | (min, max) | String length in range     | `{"str_length": (1, 100)}`   |
 
+`str_regex` applies your pattern as written: it matches anywhere in the value unless you anchor it
+yourself. Use `r"^\d+"` to require a match at the start and `r"^\d+$"` to require a full match.
+
+Nulls count as failures for every check. A null in a checked column is reported as a violation
+rather than skipped, on all supported backends.
+
 ### Multiple Checks
 
 You can combine multiple checks on a single column:

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -317,6 +317,11 @@ def process_data(df):
 `str_regex` applies your pattern as written: it matches anywhere in the value unless you anchor it
 yourself. Use `r"^\d+"` to require a match at the start and `r"^\d+$"` to require a full match.
 
+The pattern is handed to the DataFrame library's own regex engine, so advanced syntax is not
+portable. Lookarounds and backreferences work on Pandas (Python `re`) but raise `ComputeError` on
+Polars and `ArrowInvalid` on PyArrow. Stick to basic syntax if your code runs on more than one
+backend.
+
 Checks constrain values, and a null is not a value. Daffy does not rewrite null comparison
 results, so null handling follows your backend: on Polars, PyArrow and Pandas nullable dtypes
 a comparison against null is "unknown" and is not reported, while Pandas float `NaN` compares
@@ -463,7 +468,7 @@ def process_inventory(df):
 
 If any rows fail validation, you'll get a detailed error message:
 
-```python
+```
 AssertionError: Row validation failed for 2 out of 100 rows:
 
   Row 5:

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -313,8 +313,11 @@ def process_data(df):
 `str_regex` applies your pattern as written: it matches anywhere in the value unless you anchor it
 yourself. Use `r"^\d+"` to require a match at the start and `r"^\d+$"` to require a full match.
 
-Nulls count as failures for every check. A null in a checked column is reported as a violation
-rather than skipped, on all supported backends.
+Checks constrain values, and a null is not a value. Daffy does not rewrite null comparison
+results, so null handling follows your backend: on Polars, PyArrow and Pandas nullable dtypes
+a comparison against null is "unknown" and is not reported, while Pandas float `NaN` compares
+as `False` and therefore does fail. Use `nullable=False` or the `notnull` check to constrain
+nulls explicitly — those work identically everywhere.
 
 ### Multiple Checks
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -20,6 +20,10 @@ In this example:
 - The DataFrame must have a column named exactly "Brand"
 - The DataFrame must have at least one column matching the pattern "Price_\d+" (e.g., "Price_1", "Price_2", etc.)
 
+The pattern is applied as written and matches anywhere in the column name, so `r/Price_\d+/` also
+matches `Total_Price_1`. Anchor it yourself when you need a tighter match: `r/^Price_\d+/` requires
+the name to start with the pattern, and `r/^Price_\d+$/` requires the whole name to match.
+
 If no columns match a regex pattern, an error is raised:
 
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -231,6 +231,11 @@ Custom checks are also supported by passing a callable as the check value.
 `str_regex` applies your pattern as written: it matches anywhere in the value unless you anchor it
 yourself. Use `r"^\d+"` to require a match at the start and `r"^\d+$"` to require a full match.
 
+The pattern is handed to the DataFrame library's own regex engine, so advanced syntax is not
+portable. Lookarounds and backreferences work on Pandas (Python `re`) but raise `ComputeError` on
+Polars and `ArrowInvalid` on PyArrow. Stick to basic syntax if your code runs on more than one
+backend.
+
 Checks constrain values, and a null is not a value. Daffy does not rewrite null comparison
 results, so null handling follows your backend: on Polars, PyArrow and Pandas nullable dtypes
 a comparison against null is "unknown" and is not reported, while Pandas float `NaN` compares

--- a/docs/api.md
+++ b/docs/api.md
@@ -160,6 +160,19 @@ Map column names to expected dtypes:
 columns={"a": "int64", "b": "object", "c": "float64"}
 ```
 
+Parameterised dtypes can be declared by base name, which matches whatever parameters the column
+carries. Spell the parameters out when you want to constrain them:
+
+```python
+columns={"created_at": "datetime"}                                  # any time unit or time zone
+columns={"created_at": "datetime(time_unit='ns', time_zone=none)"}  # exactly this one
+columns={"tags": "list", "address": "struct", "grade": "enum"}
+```
+
+Note that `"object"` and `"str"` both mean "string" — a Pandas `object` column is reported as a
+string regardless of what it holds, so `{"a": "str"}` will not catch an `object` column containing
+numbers or dicts.
+
 ### Rich Column Spec
 
 Full control over column validation:

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,8 +218,11 @@ Custom checks are also supported by passing a callable as the check value.
 `str_regex` applies your pattern as written: it matches anywhere in the value unless you anchor it
 yourself. Use `r"^\d+"` to require a match at the start and `r"^\d+$"` to require a full match.
 
-Nulls count as failures for every check. A null in a checked column is reported as a violation
-rather than skipped, on all supported backends.
+Checks constrain values, and a null is not a value. Daffy does not rewrite null comparison
+results, so null handling follows your backend: on Polars, PyArrow and Pandas nullable dtypes
+a comparison against null is "unknown" and is not reported, while Pandas float `NaN` compares
+as `False` and therefore does fail. Use `nullable=False` or the `notnull` check to constrain
+nulls explicitly — those work identically everywhere.
 
 **Examples:**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -215,6 +215,12 @@ Available built-in checks for the `checks` parameter:
 
 Custom checks are also supported by passing a callable as the check value.
 
+`str_regex` applies your pattern as written: it matches anywhere in the value unless you anchor it
+yourself. Use `r"^\d+"` to require a match at the start and `r"^\d+$"` to require a full match.
+
+Nulls count as failures for every check. A null in a checked column is reported as a violation
+rather than skipped, on all supported backends.
+
 **Examples:**
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "2.8.0"
+version = "3.0.0"
 description = "Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow."
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -206,6 +206,30 @@ class TestStrRegexCheck:
         assert fail_count == 1
         assert samples == ["invalid"]
 
+    def test_str_regex_matches_anywhere_in_the_value(self) -> None:
+        series = pd.Series(["abc123", "abc"])
+        fail_count, samples = apply_check(series, "str_regex", r"\d+")
+        assert fail_count == 1
+        assert samples == ["abc"]
+
+    def test_str_regex_honours_caller_start_anchor(self) -> None:
+        series = pd.Series(["123abc", "abc123"])
+        fail_count, samples = apply_check(series, "str_regex", r"^\d+")
+        assert fail_count == 1
+        assert samples == ["abc123"]
+
+    def test_str_regex_honours_caller_full_match_anchors(self) -> None:
+        series = pd.Series(["123", "123abc"])
+        fail_count, samples = apply_check(series, "str_regex", r"^\d+$")
+        assert fail_count == 1
+        assert samples == ["123abc"]
+
+    def test_str_regex_alternation_is_not_rewritten(self) -> None:
+        series = pd.Series(["xb", "c"])
+        fail_count, samples = apply_check(series, "str_regex", "a|b")
+        assert fail_count == 1
+        assert samples == ["c"]
+
 
 class TestStrStartswithCheck:
     def test_str_startswith_passes(self) -> None:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -10,19 +10,34 @@ import pytest
 
 from daffy.checks import apply_check, validate_checks
 
-NUMERIC_WITH_NULL = [
-    pytest.param(pd.Series([1.0, None, 3.0]), id="pandas-float"),
-    pytest.param(pd.Series([1, None, 3], dtype="Int64"), id="pandas-nullable-int"),
-    pytest.param(pl.Series([1, None, 3]), id="polars"),
-    pytest.param(pa.chunked_array([[1, None, 3]]), id="pyarrow"),
-]
 
-STRINGS_WITH_NULL = [
-    pytest.param(pd.Series(["ab1x", None, "ab2x"]), id="pandas-object"),
-    pytest.param(pd.Series(["ab1x", None, "ab2x"], dtype="string"), id="pandas-string"),
-    pytest.param(pl.Series(["ab1x", None, "ab2x"]), id="polars"),
-    pytest.param(pa.chunked_array([["ab1x", None, "ab2x"]]), id="pyarrow"),
-]
+def numeric_with_null(backend: str) -> Any:
+    """Build [1, null, 3] on the requested backend."""
+    return {
+        "pandas-float": lambda: pd.Series([1.0, None, 3.0]),
+        "pandas-nullable-int": lambda: pd.Series([1, None, 3], dtype="Int64"),
+        "polars": lambda: pl.Series([1, None, 3]),
+        "pyarrow": lambda: pa.chunked_array([[1, None, 3]]),
+    }[backend]()
+
+
+def strings_with_null(backend: str) -> Any:
+    """Build ["ab1x", null, "ab2x"] on the requested backend."""
+    return {
+        "pandas-object": lambda: pd.Series(["ab1x", None, "ab2x"]),
+        "pandas-string": lambda: pd.Series(["ab1x", None, "ab2x"], dtype="string"),
+        "polars": lambda: pl.Series(["ab1x", None, "ab2x"]),
+        "pyarrow": lambda: pa.chunked_array([["ab1x", None, "ab2x"]]),
+    }[backend]()
+
+
+NUMERIC_BACKENDS = ["pandas-float", "pandas-nullable-int", "polars", "pyarrow"]
+STRING_BACKENDS = ["pandas-object", "pandas-string", "polars", "pyarrow"]
+
+# Backends whose nulls are three-valued: a comparison against null yields "unknown",
+# which is not a violation. Pandas float NaN is the exception - it compares as False,
+# so NaN fails comparisons natively.
+THREE_VALUED_NUMERIC = ["pandas-nullable-int", "polars", "pyarrow"]
 
 
 class TestComparisonChecks:
@@ -72,7 +87,8 @@ class TestComparisonChecks:
         assert fail_count == 1
         assert samples == [15]
 
-    def test_null_values_treated_as_failures(self) -> None:
+    def test_pandas_float_nan_fails_comparison(self) -> None:
+        """NaN compares as False in Pandas float columns, so it fails natively."""
         series = pd.Series([1, None, 3])
         fail_count, _samples = apply_check(series, "gt", 0)
         assert fail_count == 1
@@ -368,41 +384,53 @@ class TestEdgeCases:
         assert fail_count == 3
 
 
-class TestNullsCountAsFailuresAcrossBackends:
-    """A null in a checked column is a failure on every backend, not a silently skipped row."""
+class TestNullSemanticsFollowTheBackend:
+    """Checks constrain values; a null is not a value.
 
-    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
-    def test_comparison_check(self, series: Any) -> None:
-        fail_count, samples = apply_check(series, "gt", 0)
-        assert fail_count == 1
-        assert len(samples) == 1
+    Daffy does not rewrite null comparison results. On backends with three-valued logic
+    (Polars, PyArrow, Pandas nullable dtypes) comparing against a null yields "unknown",
+    which is not a violation. Pandas float NaN is the exception: it compares as False
+    natively, so NaN does fail a comparison there. Use `nullable=False` or the `notnull`
+    check to constrain nulls explicitly.
+    """
 
-    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
-    def test_between_check(self, series: Any) -> None:
-        fail_count, _samples = apply_check(series, "between", (0, 10))
-        assert fail_count == 1
+    @pytest.mark.parametrize("backend", THREE_VALUED_NUMERIC)
+    @pytest.mark.parametrize(
+        ("check_name", "check_value"),
+        [("gt", 0), ("ge", 1), ("lt", 9), ("le", 9), ("between", (0, 9))],
+    )
+    def test_comparison_ignores_null_on_three_valued_backends(
+        self, backend: str, check_name: str, check_value: Any
+    ) -> None:
+        fail_count, _samples = apply_check(numeric_with_null(backend), check_name, check_value)
+        assert fail_count == 0
 
-    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
-    def test_isin_check(self, series: Any) -> None:
-        fail_count, _samples = apply_check(series, "isin", [1, 3])
-        assert fail_count == 1
-
-    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
-    def test_eq_check(self, series: Any) -> None:
-        fail_count, _samples = apply_check(series, "eq", 1)
-        assert fail_count == 2
-
-    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
-    def test_notnull_check(self, series: Any) -> None:
-        fail_count, _samples = apply_check(series, "notnull", True)
+    @pytest.mark.parametrize(("check_name", "check_value"), [("gt", 0), ("between", (0, 9))])
+    def test_comparison_fails_nan_on_pandas_float(self, check_name: str, check_value: Any) -> None:
+        fail_count, _samples = apply_check(numeric_with_null("pandas-float"), check_name, check_value)
         assert fail_count == 1
 
-    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
-    def test_custom_check(self, series: Any) -> None:
-        fail_count, _samples = apply_check(series, "positive", lambda s: s > 0)
+    @pytest.mark.parametrize("backend", NUMERIC_BACKENDS)
+    def test_ne_ignores_null_everywhere(self, backend: str) -> None:
+        fail_count, _samples = apply_check(numeric_with_null(backend), "ne", 9)
+        assert fail_count == 0
+
+    @pytest.mark.parametrize("backend", NUMERIC_BACKENDS)
+    def test_notin_ignores_null_everywhere(self, backend: str) -> None:
+        fail_count, _samples = apply_check(numeric_with_null(backend), "notin", [9])
+        assert fail_count == 0
+
+    @pytest.mark.parametrize("backend", NUMERIC_BACKENDS)
+    def test_notnull_reports_null_everywhere(self, backend: str) -> None:
+        fail_count, _samples = apply_check(numeric_with_null(backend), "notnull", True)
         assert fail_count == 1
 
-    @pytest.mark.parametrize("series", STRINGS_WITH_NULL)
+    @pytest.mark.parametrize("backend", THREE_VALUED_NUMERIC)
+    def test_custom_check_ignores_null_on_three_valued_backends(self, backend: str) -> None:
+        fail_count, _samples = apply_check(numeric_with_null(backend), "positive", lambda s: s > 0)
+        assert fail_count == 0
+
+    @pytest.mark.parametrize("backend", STRING_BACKENDS)
     @pytest.mark.parametrize(
         ("check_name", "check_value"),
         [
@@ -410,12 +438,17 @@ class TestNullsCountAsFailuresAcrossBackends:
             ("str_startswith", "ab"),
             ("str_endswith", "x"),
             ("str_contains", "b"),
-            ("str_length", (4, 4)),
         ],
     )
-    def test_string_check(self, series: Any, check_name: str, check_value: Any) -> None:
-        fail_count, _samples = apply_check(series, check_name, check_value)
-        assert fail_count == 1
+    def test_string_check_ignores_null(self, backend: str, check_name: str, check_value: Any) -> None:
+        fail_count, _samples = apply_check(strings_with_null(backend), check_name, check_value)
+        assert fail_count == 0
+
+    @pytest.mark.parametrize("backend", STRING_BACKENDS)
+    def test_string_check_does_not_crash_on_pandas_object_nulls(self, backend: str) -> None:
+        """Regression: `~` on a pandas object-dtype mask holding None raised TypeError."""
+        fail_count, _samples = apply_check(strings_with_null(backend), "str_regex", r"nomatch")
+        assert fail_count == 2
 
 
 class TestValidateChecks:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,10 +1,28 @@
 """Tests for value checks."""
 
+from typing import Any
+
 import narwhals as nw
 import pandas as pd
+import polars as pl
+import pyarrow as pa
 import pytest
 
 from daffy.checks import apply_check, validate_checks
+
+NUMERIC_WITH_NULL = [
+    pytest.param(pd.Series([1.0, None, 3.0]), id="pandas-float"),
+    pytest.param(pd.Series([1, None, 3], dtype="Int64"), id="pandas-nullable-int"),
+    pytest.param(pl.Series([1, None, 3]), id="polars"),
+    pytest.param(pa.chunked_array([[1, None, 3]]), id="pyarrow"),
+]
+
+STRINGS_WITH_NULL = [
+    pytest.param(pd.Series(["ab1x", None, "ab2x"]), id="pandas-object"),
+    pytest.param(pd.Series(["ab1x", None, "ab2x"], dtype="string"), id="pandas-string"),
+    pytest.param(pl.Series(["ab1x", None, "ab2x"]), id="polars"),
+    pytest.param(pa.chunked_array([["ab1x", None, "ab2x"]]), id="pyarrow"),
+]
 
 
 class TestComparisonChecks:
@@ -324,6 +342,56 @@ class TestEdgeCases:
         series = pd.Series([None, None, None])
         fail_count, _samples = apply_check(series, "gt", 0)
         assert fail_count == 3
+
+
+class TestNullsCountAsFailuresAcrossBackends:
+    """A null in a checked column is a failure on every backend, not a silently skipped row."""
+
+    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
+    def test_comparison_check(self, series: Any) -> None:
+        fail_count, samples = apply_check(series, "gt", 0)
+        assert fail_count == 1
+        assert len(samples) == 1
+
+    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
+    def test_between_check(self, series: Any) -> None:
+        fail_count, _samples = apply_check(series, "between", (0, 10))
+        assert fail_count == 1
+
+    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
+    def test_isin_check(self, series: Any) -> None:
+        fail_count, _samples = apply_check(series, "isin", [1, 3])
+        assert fail_count == 1
+
+    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
+    def test_eq_check(self, series: Any) -> None:
+        fail_count, _samples = apply_check(series, "eq", 1)
+        assert fail_count == 2
+
+    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
+    def test_notnull_check(self, series: Any) -> None:
+        fail_count, _samples = apply_check(series, "notnull", True)
+        assert fail_count == 1
+
+    @pytest.mark.parametrize("series", NUMERIC_WITH_NULL)
+    def test_custom_check(self, series: Any) -> None:
+        fail_count, _samples = apply_check(series, "positive", lambda s: s > 0)
+        assert fail_count == 1
+
+    @pytest.mark.parametrize("series", STRINGS_WITH_NULL)
+    @pytest.mark.parametrize(
+        ("check_name", "check_value"),
+        [
+            ("str_regex", r"ab\dx"),
+            ("str_startswith", "ab"),
+            ("str_endswith", "x"),
+            ("str_contains", "b"),
+            ("str_length", (4, 4)),
+        ],
+    )
+    def test_string_check(self, series: Any, check_name: str, check_value: Any) -> None:
+        fail_count, _samples = apply_check(series, check_name, check_value)
+        assert fail_count == 1
 
 
 class TestValidateChecks:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -176,6 +176,22 @@ def test_get_checks_max_samples_default() -> None:
         assert get_checks_max_samples() == 5
 
 
+def test_shipped_defaults(tmp_path: Path) -> None:
+    """The defaults applied when no pyproject configures daffy."""
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        clear_config_cache()
+        config = get_config()
+
+    assert config == {
+        "strict": False,
+        "lazy": False,
+        "strict_specs": False,
+        "row_validation_max_errors": 5,
+        "checks_max_samples": 5,
+        "allow_empty": True,
+    }
+
+
 def test_get_checks_max_samples_override() -> None:
     with patch("daffy.config.get_config", return_value={"checks_max_samples": 5}):
         assert get_checks_max_samples(10) == 10

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,18 @@
 """Tests for the daffy configuration system."""
 
-import os
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from daffy.config import clear_config_cache, get_checks_max_samples, get_config, get_strict, get_strict_specs
+
+
+def write_pyproject(directory: Path, daffy_section: str) -> Path:
+    """Write a pyproject.toml with the given [tool.daffy] body and return its path."""
+    path = directory / "pyproject.toml"
+    path.write_text(f"[tool.daffy]\n{daffy_section}\n", encoding="utf-8")
+    return path
 
 
 def test_get_config_default() -> None:
@@ -53,61 +58,44 @@ def test_get_strict_specs_override() -> None:
         assert get_strict_specs(False) is False
 
 
-def test_config_from_pyproject() -> None:
+def test_config_from_pyproject(tmp_path: Path) -> None:
     """Test loading configuration from pyproject.toml."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Create a mock pyproject.toml file
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-strict = true
-            """)
+    write_pyproject(tmp_path, "strict = true")
 
-        # Test loading from this file
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
 
-            clear_config_cache()
+        clear_config_cache()
 
-            config = load_config()
-            assert config["strict"] is True
+        config = load_config()
+        assert config["strict"] is True
 
 
-def test_strict_specs_from_pyproject() -> None:
+def test_strict_specs_from_pyproject(tmp_path: Path) -> None:
     """Verify strict_specs value is read from pyproject config."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-strict_specs = true
-            """)
+    write_pyproject(tmp_path, "strict_specs = true")
 
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
 
-            clear_config_cache()
-            config = load_config()
-            assert config["strict_specs"] is True
+        clear_config_cache()
+        config = load_config()
+        assert config["strict_specs"] is True
 
 
-def test_config_strict_specs_string_raises_error() -> None:
+def test_config_strict_specs_string_raises_error(tmp_path: Path) -> None:
     """Test that non-boolean strict_specs config raises TypeError."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-strict_specs = "true"
-            """)
+    write_pyproject(tmp_path, 'strict_specs = "true"')
 
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
 
-            clear_config_cache()
+        clear_config_cache()
 
-            with pytest.raises(TypeError) as exc_info:
-                load_config()
-            assert "strict_specs" in str(exc_info.value)
-            assert "boolean" in str(exc_info.value)
+        with pytest.raises(TypeError) as exc_info:
+            load_config()
+        assert "strict_specs" in str(exc_info.value)
+        assert "boolean" in str(exc_info.value)
 
 
 def test_load_config_returns_default_when_file_not_found() -> None:
@@ -116,88 +104,71 @@ def test_load_config_returns_default_when_file_not_found() -> None:
         assert config["strict"] is False
 
 
-def test_load_config_returns_default_when_toml_malformed() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("invalid toml [[[")
+def test_load_config_returns_default_when_toml_malformed(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("invalid toml [[[", encoding="utf-8")
 
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            clear_config_cache()
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        clear_config_cache()
 
-            config = get_config()
-            assert config["strict"] is False
+        config = get_config()
+        assert config["strict"] is False
 
 
-def test_find_config_file_returns_none_when_no_pyproject_exists() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir, patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
+def test_find_config_file_returns_none_when_no_pyproject_exists(tmp_path: Path) -> None:
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
         from daffy.config import find_config_file
 
         result = find_config_file()
         assert result is None
 
 
-def test_find_config_file_searches_parent_directories() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        project_dir = Path(tmpdir) / "project"
-        nested_dir = project_dir / "src" / "module"
-        nested_dir.mkdir(parents=True)
-        pyproject_path = project_dir / "pyproject.toml"
-        pyproject_path.write_text("[tool.daffy]\nstrict = true\n", encoding="utf-8")
+def test_find_config_file_searches_parent_directories(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    nested_dir = project_dir / "src" / "module"
+    nested_dir.mkdir(parents=True)
+    pyproject_path = write_pyproject(project_dir, "strict = true")
 
-        with patch("daffy.config.Path.cwd", return_value=nested_dir):
-            from daffy.config import find_config_file
+    with patch("daffy.config.Path.cwd", return_value=nested_dir):
+        from daffy.config import find_config_file
 
-            result = find_config_file()
-            assert result == str(pyproject_path.resolve())
+        result = find_config_file()
+        assert result == str(pyproject_path.resolve())
 
 
-def test_find_config_file_prefers_nearest_parent() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        project_dir = Path(tmpdir) / "project"
-        package_dir = project_dir / "pkg"
-        nested_dir = package_dir / "tests"
-        nested_dir.mkdir(parents=True)
+def test_find_config_file_prefers_nearest_parent(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    package_dir = project_dir / "pkg"
+    nested_dir = package_dir / "tests"
+    nested_dir.mkdir(parents=True)
 
-        root_pyproject = project_dir / "pyproject.toml"
-        package_pyproject = package_dir / "pyproject.toml"
-        root_pyproject.write_text("[tool.daffy]\nstrict = false\n", encoding="utf-8")
-        package_pyproject.write_text("[tool.daffy]\nstrict = true\n", encoding="utf-8")
+    write_pyproject(project_dir, "strict = false")
+    package_pyproject = write_pyproject(package_dir, "strict = true")
 
-        with patch("daffy.config.Path.cwd", return_value=nested_dir):
-            from daffy.config import find_config_file
+    with patch("daffy.config.Path.cwd", return_value=nested_dir):
+        from daffy.config import find_config_file
 
-            result = find_config_file()
-            assert result == str(package_pyproject.resolve())
+        result = find_config_file()
+        assert result == str(package_pyproject.resolve())
 
 
-def test_load_config_without_strict_setting() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-other_setting = "value"
-            """)
+def test_load_config_without_strict_setting(tmp_path: Path) -> None:
+    write_pyproject(tmp_path, 'other_setting = "value"')
 
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            clear_config_cache()
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        clear_config_cache()
 
-            config = get_config()
-            assert config["strict"] is False
+        config = get_config()
+        assert config["strict"] is False
 
 
-def test_load_config_daffy_section_without_strict() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-some_other_setting = "value"
-            """)
+def test_load_config_daffy_section_without_strict(tmp_path: Path) -> None:
+    write_pyproject(tmp_path, 'some_other_setting = "value"')
 
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            clear_config_cache()
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        clear_config_cache()
 
-            config = get_config()
-            assert config["strict"] is False
+        config = get_config()
+        assert config["strict"] is False
 
 
 def test_get_checks_max_samples_default() -> None:
@@ -210,177 +181,139 @@ def test_get_checks_max_samples_override() -> None:
         assert get_checks_max_samples(10) == 10
 
 
-def test_checks_max_samples_from_pyproject() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-checks_max_samples = 10
-            """)
+def test_checks_max_samples_from_pyproject(tmp_path: Path) -> None:
+    write_pyproject(tmp_path, "checks_max_samples = 10")
 
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
-
-            clear_config_cache()
-
-            config = load_config()
-            assert config["checks_max_samples"] == 10
-
-
-def test_config_strict_string_raises_error() -> None:
-    """Test that non-boolean strict config raises TypeError."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-strict = "false"
-            """)
-
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
-
-            clear_config_cache()
-
-            with pytest.raises(TypeError) as exc_info:
-                load_config()
-            assert "strict" in str(exc_info.value)
-            assert "boolean" in str(exc_info.value)
-
-
-def test_config_max_samples_string_raises_error() -> None:
-    """Test that non-integer max_samples config raises TypeError."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-checks_max_samples = "five"
-            """)
-
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
-
-            clear_config_cache()
-
-            with pytest.raises(TypeError) as exc_info:
-                load_config()
-            assert "checks_max_samples" in str(exc_info.value)
-            assert "integer" in str(exc_info.value)
-
-
-def test_config_max_samples_zero_raises_error() -> None:
-    """Test that max_samples < 1 raises ValueError."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-checks_max_samples = 0
-            """)
-
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
-
-            clear_config_cache()
-
-            with pytest.raises(ValueError) as exc_info:
-                load_config()
-            assert "checks_max_samples" in str(exc_info.value)
-            assert ">= 1" in str(exc_info.value)
-
-
-def test_config_max_samples_one_passes() -> None:
-    """Test that max_samples = 1 is valid (boundary value)."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-checks_max_samples = 1
-            """)
-
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
-
-            clear_config_cache()
-
-            config = load_config()
-            assert config["checks_max_samples"] == 1
-
-
-def test_config_row_validation_max_errors_one_passes() -> None:
-    """Test that row_validation_max_errors = 1 is valid (boundary value)."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-row_validation_max_errors = 1
-            """)
-
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
-
-            clear_config_cache()
-
-            config = load_config()
-            assert config["row_validation_max_errors"] == 1
-
-
-def test_config_row_validation_max_errors_zero_raises_error() -> None:
-    """Test that row_validation_max_errors < 1 raises ValueError."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "pyproject.toml"), "w") as f:
-            f.write("""
-[tool.daffy]
-row_validation_max_errors = 0
-            """)
-
-        with patch("daffy.config.Path.cwd", return_value=Path(tmpdir)):
-            from daffy.config import load_config
-
-            clear_config_cache()
-
-            with pytest.raises(ValueError) as exc_info:
-                load_config()
-            assert "row_validation_max_errors" in str(exc_info.value)
-            assert ">= 1" in str(exc_info.value)
-
-
-def test_get_config_cache_isolated_by_cwd() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        project_dir = Path(tmpdir) / "project"
-        nested_dir = project_dir / "src"
-        external_dir = Path(tmpdir) / "external"
-        nested_dir.mkdir(parents=True)
-        external_dir.mkdir(parents=True)
-
-        (project_dir / "pyproject.toml").write_text("[tool.daffy]\nstrict = true\n", encoding="utf-8")
-
-        clear_config_cache()
-        with patch("daffy.config.Path.cwd", return_value=nested_dir):
-            nested_config = get_config()
-            assert nested_config["strict"] is True
-
-        with patch("daffy.config.Path.cwd", return_value=external_dir):
-            external_config = get_config()
-            assert external_config["strict"] is False
-
-
-def test_get_config_uses_cache_for_same_cwd() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        pyproject_path = Path(tmpdir) / "pyproject.toml"
-        pyproject_path.write_text("[tool.daffy]\nstrict = true\n", encoding="utf-8")
-
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
         from daffy.config import load_config
 
         clear_config_cache()
-        with (
-            patch("daffy.config.Path.cwd", return_value=Path(tmpdir)),
-            patch("daffy.config.load_config", wraps=load_config) as mocked_load_config,
-        ):
-            first = get_config()
-            second = get_config()
 
-            assert first["strict"] is True
-            assert second["strict"] is True
-            assert mocked_load_config.call_count == 1
+        config = load_config()
+        assert config["checks_max_samples"] == 10
+
+
+def test_config_strict_string_raises_error(tmp_path: Path) -> None:
+    """Test that non-boolean strict config raises TypeError."""
+    write_pyproject(tmp_path, 'strict = "false"')
+
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
+
+        clear_config_cache()
+
+        with pytest.raises(TypeError) as exc_info:
+            load_config()
+        assert "strict" in str(exc_info.value)
+        assert "boolean" in str(exc_info.value)
+
+
+def test_config_max_samples_string_raises_error(tmp_path: Path) -> None:
+    """Test that non-integer max_samples config raises TypeError."""
+    write_pyproject(tmp_path, 'checks_max_samples = "five"')
+
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
+
+        clear_config_cache()
+
+        with pytest.raises(TypeError) as exc_info:
+            load_config()
+        assert "checks_max_samples" in str(exc_info.value)
+        assert "integer" in str(exc_info.value)
+
+
+def test_config_max_samples_zero_raises_error(tmp_path: Path) -> None:
+    """Test that max_samples < 1 raises ValueError."""
+    write_pyproject(tmp_path, "checks_max_samples = 0")
+
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
+
+        clear_config_cache()
+
+        with pytest.raises(ValueError) as exc_info:
+            load_config()
+        assert "checks_max_samples" in str(exc_info.value)
+        assert ">= 1" in str(exc_info.value)
+
+
+def test_config_max_samples_one_passes(tmp_path: Path) -> None:
+    """Test that max_samples = 1 is valid (boundary value)."""
+    write_pyproject(tmp_path, "checks_max_samples = 1")
+
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
+
+        clear_config_cache()
+
+        config = load_config()
+        assert config["checks_max_samples"] == 1
+
+
+def test_config_row_validation_max_errors_one_passes(tmp_path: Path) -> None:
+    """Test that row_validation_max_errors = 1 is valid (boundary value)."""
+    write_pyproject(tmp_path, "row_validation_max_errors = 1")
+
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
+
+        clear_config_cache()
+
+        config = load_config()
+        assert config["row_validation_max_errors"] == 1
+
+
+def test_config_row_validation_max_errors_zero_raises_error(tmp_path: Path) -> None:
+    """Test that row_validation_max_errors < 1 raises ValueError."""
+    write_pyproject(tmp_path, "row_validation_max_errors = 0")
+
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
+
+        clear_config_cache()
+
+        with pytest.raises(ValueError) as exc_info:
+            load_config()
+        assert "row_validation_max_errors" in str(exc_info.value)
+        assert ">= 1" in str(exc_info.value)
+
+
+def test_get_config_cache_isolated_by_cwd(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    nested_dir = project_dir / "src"
+    external_dir = tmp_path / "external"
+    nested_dir.mkdir(parents=True)
+    external_dir.mkdir(parents=True)
+
+    write_pyproject(project_dir, "strict = true")
+
+    clear_config_cache()
+    with patch("daffy.config.Path.cwd", return_value=nested_dir):
+        nested_config = get_config()
+        assert nested_config["strict"] is True
+
+    with patch("daffy.config.Path.cwd", return_value=external_dir):
+        external_config = get_config()
+        assert external_config["strict"] is False
+
+
+def test_get_config_uses_cache_for_same_cwd(tmp_path: Path) -> None:
+    write_pyproject(tmp_path, "strict = true")
+
+    from daffy.config import load_config
+
+    clear_config_cache()
+    with (
+        patch("daffy.config.Path.cwd", return_value=tmp_path),
+        patch("daffy.config.load_config", wraps=load_config) as mocked_load_config,
+    ):
+        first = get_config()
+        second = get_config()
+
+        assert first["strict"] is True
+        assert second["strict"] is True
+        assert mocked_load_config.call_count == 1
 
 
 def test_get_int_config_invalid_override() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,17 @@
 """Tests for the daffy configuration system."""
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
-from daffy.config import clear_config_cache, get_checks_max_samples, get_config, get_strict, get_strict_specs
+from daffy.config import (
+    clear_config_cache,
+    get_checks_max_samples,
+    get_config,
+    resolve_decorator_settings,
+)
 
 
 def write_pyproject(directory: Path, daffy_section: str) -> Path:
@@ -22,40 +28,42 @@ def test_get_config_default() -> None:
         assert config["strict"] is False
 
 
-def test_get_strict_default() -> None:
-    """Test that get_strict returns default value when no explicit value is provided."""
-    with patch("daffy.config.get_config", return_value={"strict": False}):
-        assert get_strict() is False
-
-    with patch("daffy.config.get_config", return_value={"strict": True}):
-        assert get_strict() is True
-
-
-def test_get_strict_override() -> None:
-    """Test that get_strict respects explicitly provided value."""
-    with patch("daffy.config.get_config", return_value={"strict": False}):
-        assert get_strict(True) is True
-
-    with patch("daffy.config.get_config", return_value={"strict": True}):
-        assert get_strict(False) is False
+def _config(**overrides: Any) -> dict[str, Any]:
+    defaults = {
+        "strict": False,
+        "lazy": False,
+        "strict_specs": False,
+        "row_validation_max_errors": 5,
+        "checks_max_samples": 5,
+        "allow_empty": True,
+    }
+    return {**defaults, **overrides}
 
 
-def test_get_strict_specs_default() -> None:
-    """Verify default strict_specs value is read from config."""
-    with patch("daffy.config.get_config", return_value={"strict_specs": False}):
-        assert get_strict_specs() is False
+@pytest.mark.parametrize("setting", ["strict", "lazy", "allow_empty"])
+@pytest.mark.parametrize("configured", [True, False])
+def test_settings_fall_back_to_config(setting: str, configured: bool) -> None:
+    with patch("daffy.config.get_config", return_value=_config(**{setting: configured})):
+        settings = resolve_decorator_settings(None, None, None)
 
-    with patch("daffy.config.get_config", return_value={"strict_specs": True}):
-        assert get_strict_specs() is True
+    assert getattr(settings, setting) is configured
 
 
-def test_get_strict_specs_override() -> None:
-    """Verify strict_specs override argument takes precedence over config."""
-    with patch("daffy.config.get_config", return_value={"strict_specs": False}):
-        assert get_strict_specs(True) is True
+@pytest.mark.parametrize(("position", "setting"), [(0, "strict"), (1, "lazy"), (2, "allow_empty")])
+@pytest.mark.parametrize("explicit", [True, False])
+def test_explicit_argument_beats_config(position: int, setting: str, explicit: bool) -> None:
+    args: list[bool | None] = [None, None, None]
+    args[position] = explicit
 
-    with patch("daffy.config.get_config", return_value={"strict_specs": True}):
-        assert get_strict_specs(False) is False
+    with patch("daffy.config.get_config", return_value=_config(**{setting: not explicit})):
+        settings = resolve_decorator_settings(*args)
+
+    assert getattr(settings, setting) is explicit
+
+
+def test_strict_specs_is_read_from_config() -> None:
+    with patch("daffy.config.get_config", return_value=_config(strict_specs=True)):
+        assert resolve_decorator_settings(None, None, None).strict_specs is True
 
 
 def test_config_from_pyproject(tmp_path: Path) -> None:

--- a/tests/test_custom_checks.py
+++ b/tests/test_custom_checks.py
@@ -38,10 +38,11 @@ class TestCustomCheckFunctions:
         assert fail_count == 0
         assert samples == []
 
-    def test_custom_check_with_nulls_treated_as_failure(self) -> None:
+    def test_custom_check_with_pandas_float_nan(self) -> None:
+        """NaN compares as False in Pandas float columns, so it fails the custom check natively."""
         series = pd.Series([1, None, 3])
         fail_count, _samples = apply_check(series, "positive", lambda s: s > 0)
-        assert fail_count == 1  # null is treated as failure
+        assert fail_count == 1
 
     def test_custom_check_max_samples(self) -> None:
         series = pd.Series([-1, -2, -3, -4, -5, -6, -7, -8, -9, -10])

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -6,6 +6,7 @@ import polars as pl
 import pytest
 
 from daffy import df_in
+from daffy.config import get_config
 from daffy.utils import ParameterResolver
 from tests.conftest import IntoDataFrame, cars, extended_cars
 
@@ -408,7 +409,7 @@ def test_check_columns_invalid_column_type_in_list_raises_when_strict_specs_enab
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
 
     with (
-        patch("daffy.decorators.get_strict_specs", return_value=True),
+        patch("daffy.config.get_config", return_value={**get_config(), "strict_specs": True}),
         pytest.raises(TypeError, match="Invalid column spec at index 1"),
     ):
         process(df)
@@ -437,7 +438,7 @@ def test_check_columns_invalid_column_key_in_dict_raises_when_strict_specs_enabl
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
 
     with (
-        patch("daffy.decorators.get_strict_specs", return_value=True),
+        patch("daffy.config.get_config", return_value={**get_config(), "strict_specs": True}),
         pytest.raises(TypeError, match="Invalid column key at index 1"),
     ):
         process(df)

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -131,6 +131,27 @@ def test_in_strict_extra_columns(df: IntoDataFrame) -> None:
     assert "DataFrame in function 'test_fn' parameter '_df' contained unexpected column(s): Price" in str(excinfo.value)
 
 
+@pytest.mark.parametrize("df", [pd.DataFrame(cars), pl.DataFrame(cars)])
+def test_in_strict_accepts_regex_matched_columns(df: IntoDataFrame) -> None:
+    """Columns matched by a regex pattern are allowed under strict mode."""
+
+    @df_in(columns=["Brand", r"r/^Price$/"], strict=True)
+    def test_fn(_df: IntoDataFrame) -> IntoDataFrame:
+        return _df
+
+    assert test_fn(df) is df
+
+
+@pytest.mark.parametrize("df", [pd.DataFrame(extended_cars), pl.DataFrame(extended_cars)])
+def test_in_strict_still_rejects_columns_no_pattern_matches(df: IntoDataFrame) -> None:
+    @df_in(columns=["Brand", r"r/^Price$/"], strict=True)
+    def test_fn(_df: IntoDataFrame) -> IntoDataFrame:
+        return _df
+
+    with pytest.raises(AssertionError, match="unexpected column\\(s\\): Year"):
+        test_fn(df)
+
+
 def test_correct_input_with_columns_and_dtypes_pandas(basic_pandas_df: pd.DataFrame) -> None:
     @df_in(columns={"Brand": "object", "Price": "int64"})
     def test_fn(my_input: Any) -> Any:

--- a/tests/test_df_in_row_validation.py
+++ b/tests/test_df_in_row_validation.py
@@ -115,3 +115,28 @@ def test_df_in_without_row_validator() -> None:
 
     result = process_people(df)
     assert result.equals(df)
+
+
+class TestMaxErrorsBoundary:
+    """row_validation_max_errors caps how many failing rows are listed, not how many exist."""
+
+    @staticmethod
+    def _run_with_bad_rows(count: int) -> str:
+        @df_in(row_validator=PersonValidator)
+        def process_people(df: Any) -> Any:
+            return df
+
+        df = pd.DataFrame({"name": ["A"] * count, "age": [-5] * count})
+        with pytest.raises(AssertionError) as exc_info:
+            process_people(df)
+        return str(exc_info.value)
+
+    def test_lists_every_failing_row_up_to_the_limit(self) -> None:
+        message = self._run_with_bad_rows(5)
+        assert message.count("  Row ") == 5
+        assert message.startswith("Row validation failed for 5 out of 5 rows:")
+
+    def test_stops_listing_past_the_limit(self) -> None:
+        message = self._run_with_bad_rows(8)
+        assert message.count("  Row ") == 5
+        assert "at least" in message

--- a/tests/test_lazy_validation.py
+++ b/tests/test_lazy_validation.py
@@ -165,15 +165,15 @@ class TestLazyValidationConfig:
         clear_config_cache()
 
     def test_lazy_defaults_to_false(self) -> None:
-        from daffy.config import get_lazy
+        from daffy.config import resolve_decorator_settings
 
-        assert get_lazy() is False
+        assert resolve_decorator_settings(None, None, None).lazy is False
 
     def test_lazy_param_overrides_config(self) -> None:
-        from daffy.config import get_lazy
+        from daffy.config import resolve_decorator_settings
 
-        assert get_lazy(True) is True
-        assert get_lazy(False) is False
+        assert resolve_decorator_settings(None, True, None).lazy is True
+        assert resolve_decorator_settings(None, False, None).lazy is False
 
 
 class TestLazyValidationErrorMessages:

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from daffy.patterns import compile_regex_pattern
+from daffy.patterns import compile_regex_pattern, match_column_with_regex
 
 
 def test_invalid_regex_pattern_raises_error() -> None:
@@ -13,3 +13,26 @@ def test_invalid_regex_pattern_raises_error() -> None:
 def test_empty_regex_pattern_raises_error() -> None:
     with pytest.raises(ValueError, match="cannot be empty"):
         compile_regex_pattern("r//")
+
+
+class TestColumnPatternsAreAppliedAsWritten:
+    """Column patterns match anywhere in the name unless the caller anchors them."""
+
+    def test_matches_without_leading_anchor(self) -> None:
+        pattern = compile_regex_pattern(r"r/Price_\d+/")
+        columns = ["Price_1", "Total_Price_2", "Brand"]
+        assert match_column_with_regex(pattern, columns) == ["Price_1", "Total_Price_2"]
+
+    def test_caller_start_anchor_is_honoured(self) -> None:
+        pattern = compile_regex_pattern(r"r/^Price_\d+/")
+        columns = ["Price_1", "Total_Price_2", "Brand"]
+        assert match_column_with_regex(pattern, columns) == ["Price_1"]
+
+    def test_caller_full_match_anchors_are_honoured(self) -> None:
+        pattern = compile_regex_pattern(r"r/^Price_\d+$/")
+        columns = ["Price_1", "Price_1_eur", "Brand"]
+        assert match_column_with_regex(pattern, columns) == ["Price_1"]
+
+    def test_matches_nothing_when_no_column_contains_the_pattern(self) -> None:
+        pattern = compile_regex_pattern(r"r/Price_\d+/")
+        assert match_column_with_regex(pattern, ["Brand", "Model"]) == []

--- a/tests/test_resolver_kwargs.py
+++ b/tests/test_resolver_kwargs.py
@@ -10,7 +10,7 @@ def test_resolver_default_kwargs() -> None:
     resolver = ParameterResolver(func)
 
     # Missing optional kwarg
-    val, _ = resolver.resolve("b", 1)
+    val, _, _ = resolver.resolve("b", 1)
     assert val == 10
 
     # Missing required kwarg
@@ -29,5 +29,5 @@ def test_resolver_default_pos() -> None:
     resolver = ParameterResolver(func)
 
     # Missing optional pos arg
-    val, _ = resolver.resolve("b", 1)
+    val, _, _ = resolver.resolve("b", 1)
     assert val == 20

--- a/tests/test_shape_validation.py
+++ b/tests/test_shape_validation.py
@@ -80,9 +80,9 @@ class TestRowConstraints:
 
 class TestAllowEmpty:
     def test_config_rejects_empty(self, make_df: DataFrameFactory, monkeypatch: pytest.MonkeyPatch) -> None:
-        from daffy import decorators
+        from daffy import config
 
-        monkeypatch.setattr(decorators, "get_allow_empty", lambda x: False if x is None else x)
+        monkeypatch.setattr(config, "get_config", lambda: {**config.load_config(), "allow_empty": False})
 
         @df_out()
         def f() -> Any:
@@ -92,9 +92,9 @@ class TestAllowEmpty:
             f()
 
     def test_decorator_overrides_config(self, make_df: DataFrameFactory, monkeypatch: pytest.MonkeyPatch) -> None:
-        from daffy import decorators
+        from daffy import config
 
-        monkeypatch.setattr(decorators, "get_allow_empty", lambda x: False if x is None else x)
+        monkeypatch.setattr(config, "get_config", lambda: {**config.load_config(), "allow_empty": False})
 
         @df_out(allow_empty=True)
         def f() -> Any:

--- a/tests/test_shape_validation.py
+++ b/tests/test_shape_validation.py
@@ -159,3 +159,15 @@ class TestInvalidConstraints:
                 @decorator(**kwargs)
                 def g(df: Any) -> Any:
                     pass
+
+    def test_accepts_min_rows_equal_to_max_rows(self, make_df: DataFrameFactory) -> None:
+        """An exact-size range is a legal bound, not a contradiction."""
+
+        @df_in(min_rows=2, max_rows=2)
+        def process(df: Any) -> Any:
+            return df
+
+        process(make_df({"a": [1, 2]}))
+
+        with pytest.raises(AssertionError, match="max_rows=2"):
+            process(make_df({"a": [1, 2, 3]}))

--- a/tests/validators/test_columns.py
+++ b/tests/validators/test_columns.py
@@ -1,6 +1,10 @@
 """Tests for column validators."""
 
+from typing import Any
+
 import pandas as pd
+import polars as pl
+import pytest
 
 from daffy.validators.columns import (
     ColumnsExistValidator,
@@ -59,6 +63,51 @@ class TestDtypeValidator:
         validator = DtypeValidator({"nonexistent": "int64"})
 
         assert validator.validate(ctx) == []
+
+
+class TestParameterisedDtypes:
+    """Parameterised dtypes are declarable by base name; spell out parameters to constrain them."""
+
+    @pytest.mark.parametrize(
+        ("df", "expected"),
+        [
+            pytest.param(pd.DataFrame({"c": pd.to_datetime(["2024-01-01"])}), "datetime", id="pandas-datetime"),
+            pytest.param(
+                pd.DataFrame({"c": pd.to_datetime(["2024-01-01"]).tz_localize("UTC")}),
+                "datetime",
+                id="pandas-datetime-tz",
+            ),
+            pytest.param(pd.DataFrame({"c": pd.to_timedelta(["1 days"])}), "duration", id="pandas-duration"),
+            pytest.param(pl.DataFrame({"c": [[1, 2]]}), "list", id="polars-list"),
+            pytest.param(pl.DataFrame({"c": [{"x": 1}]}), "struct", id="polars-struct"),
+            pytest.param(pl.DataFrame({"c": ["a"]}, schema={"c": pl.Enum(["a"])}), "enum", id="polars-enum"),
+        ],
+    )
+    def test_base_name_accepted(self, df: Any, expected: str) -> None:
+        ctx = ValidationContext(df=df)
+        assert DtypeValidator({"c": expected}).validate(ctx) == []
+
+    def test_full_parameterised_spelling_still_accepted(self) -> None:
+        ctx = ValidationContext(df=pd.DataFrame({"c": pd.to_datetime(["2024-01-01"])}))
+        assert DtypeValidator({"c": "datetime(time_unit='ns', time_zone=none)"}).validate(ctx) == []
+
+    def test_parameters_are_enforced_when_spelled_out(self) -> None:
+        ctx = ValidationContext(df=pd.DataFrame({"c": pd.to_datetime(["2024-01-01"])}))
+        errors = DtypeValidator({"c": "datetime(time_unit='ms', time_zone=none)"}).validate(ctx)
+        assert len(errors) == 1
+
+    @pytest.mark.parametrize(
+        ("df", "expected"),
+        [
+            pytest.param(pd.DataFrame({"c": pd.to_datetime(["2024-01-01"])}), "int64", id="datetime-vs-int"),
+            pytest.param(pd.DataFrame({"c": pd.to_timedelta(["1 days"])}), "datetime", id="duration-vs-datetime"),
+            pytest.param(pl.DataFrame({"c": [[1, 2]]}), "struct", id="list-vs-struct"),
+            pytest.param(pl.DataFrame({"c": ["a"]}, schema={"c": pl.Enum(["a"])}), "string", id="enum-vs-string"),
+        ],
+    )
+    def test_base_name_does_not_match_a_different_dtype(self, df: Any, expected: str) -> None:
+        ctx = ValidationContext(df=df)
+        assert len(DtypeValidator({"c": expected}).validate(ctx)) == 1
 
 
 class TestNullableValidator:


### PR DESCRIPTION
Daffy 3.0.0. Three behavior changes, one bug fix, one performance pass.

Every behavior change here was found the same way: mutation-testing the suite. Each one was behaviour that no test pinned and no doc described — the anchors and the null policy could all be removed with 656 tests still green.

## Regex patterns run as written (breaking)

`str_regex` compiled the caller's pattern as `^(?:pattern)`, so `{"str_regex": r"\d+"}` meant "starts with digits", not "contains digits". Column patterns did the same thing via `re.match`, so `r/Price_\d+/` silently refused to match `Total_Price_1`. Neither was documented.

Both now apply the pattern untouched. Anchor it yourself for the old behaviour: `r"^\d+"`, `r/^Price_\d+/`. Every example in the README and docs was already anchored, so they are unaffected.

## Null handling follows the backend (breaking)

Daffy rewrote null comparison results into violations (`fill_null(True)` on the failure mask). That is daffy's overlay, not backend behaviour — Narwhals passes each backend's answer through faithfully, and on Polars, PyArrow and Pandas nullable dtypes a comparison against null is *unknown*, not *failed*.

The overlay was also applied unevenly: `ne` and `notin` never went through it, so results were ragged in a way no backend could explain — `notin` reported the null on Polars but not on Pandas or PyArrow.

Now the backends are left alone: a null is unknown, and unknown is not a violation. Pandas float `NaN` still fails comparisons because `NaN` compares as `False` natively. `nullable=False` and the `notnull` check remain the portable way to constrain nulls, and behave identically everywhere. Tests pin the resulting matrix per backend rather than asserting a uniformity that was never true.

## Parameterised dtypes are declarable

`{"created_at": "datetime"}` was rejected. The only accepted spelling was the exact internal repr, `"datetime(time_unit='ns', time_zone=none)"` — and the same applied to `duration`, `list`, `struct` and `enum`. No test covered any of these dtypes, which is why it went unnoticed. Base names now match any parameters; spelling parameters out still constrains them.

Also fixed: `str_regex`, `str_startswith`, `str_endswith` and `str_contains` raised `TypeError: bad operand type for unary ~` on Pandas object-dtype columns containing nulls.

## ~3x less per-call overhead

Profiling showed most of a decorated call was daffy's own bookkeeping, not validation:

| | before | after |
|---|---|---|
| `@df_in(columns=...)` | 212µs | 66µs |
| `@df_in(min_rows=...)` | 216µs | 69µs |
| `@df_in(dtype + checks)` | 372µs | 274µs |

Three causes: `get_config()` ran once per setting (four times per call), each resolving the working directory through a `realpath` syscall; the frame was converted to Narwhals three times per call; and the full schema was built eagerly even when nothing read dtypes. The remaining cost in the checks row is Narwhals doing the actual checking.

## Tests

747 passing, coverage 99.4%. Beyond the tests for the changes above, this closes four gaps where mutations survived the old suite: strict mode accepting regex-matched columns (documented, never exercised), the `row_validation_max_errors` boundary, `min_rows == max_rows` as a legal exact bound, and the shipped config defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parameterized data types, including exact parameter matching when specified.
  - Added clearer configuration resolution for validation settings and overrides.

- **Bug Fixes**
  - Corrected null-handling behavior across supported data backends and checks.
  - Regular-expression checks now match substrings by default, with explicit anchors supported.

- **Documentation**
  - Clarified regex anchoring, data types, backend-specific null behavior, and validation settings.
  - Added release notes for version 3.0.0.

- **Tests**
  - Expanded coverage for null handling, regex matching, configuration, data types, and validation limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->