### PR TITLE
feat: reject unknown check names at decoration time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Misspelled built-in check names are now rejected when the decorator is applied instead of on the first call with data, so `{"checks": {"gtt": 0}}` fails at import time with the list of valid names. Custom checks are unaffected: a callable check value may carry any name, exactly as at runtime.
+
 ## 3.0.0
 
 This release removes two pieces of hidden magic and makes validation roughly five times cheaper.

--- a/daffy/checks.py
+++ b/daffy/checks.py
@@ -10,7 +10,7 @@ not a violation. Use `nullable=False` or the `notnull` check to constrain nulls.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 import narwhals as nw
 
@@ -31,6 +31,8 @@ CheckName = Literal[
     "str_contains",
     "str_length",
 ]
+
+BUILTIN_CHECK_NAMES: frozenset[str] = frozenset(get_args(CheckName))
 
 CheckViolation = tuple[str, str, int, list[Any]]
 

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from daffy.dataframe_types import IntoDataFrameT
     from daffy.validation import ColumnsDef
 
+from daffy.checks import BUILTIN_CHECK_NAMES
 from daffy.config import resolve_decorator_settings
 from daffy.utils import (
     ParameterResolver,
@@ -41,6 +42,33 @@ def _validate_composite_unique(composite_unique: list[list[str]] | None) -> None
         for j, col in enumerate(combo):
             if not isinstance(col, str):
                 raise TypeError(f"composite_unique[{i}][{j}] must be a string, got {type(col).__name__}")
+
+
+def _validate_check_names(columns: ColumnsDef) -> None:
+    """Reject unknown built-in check names at decoration time.
+
+    Mirrors `apply_check`: a callable check value is a custom check and may carry any
+    name, so only non-callable values are matched against the built-ins. Without this,
+    a typo like `{"checks": {"gtt": 0}}` decorates cleanly and only fails on the first
+    call with data.
+    """
+    if not isinstance(columns, dict):
+        return
+
+    for column, spec in columns.items():
+        if not isinstance(spec, dict):
+            continue
+        checks = spec.get("checks")
+        if not isinstance(checks, dict):
+            continue
+        for check_name, check_value in checks.items():
+            if callable(check_value) or check_name in BUILTIN_CHECK_NAMES:
+                continue
+            valid = ", ".join(sorted(BUILTIN_CHECK_NAMES))
+            raise ValueError(
+                f"Unknown check '{check_name}' for column '{column}'. "
+                f"Pass a callable to define a custom check, or use one of: {valid}"
+            )
 
 
 def _validate_shape_constraints(
@@ -149,6 +177,7 @@ def df_out(
         Callable: Decorated function with preserved DataFrame return type
 
     """
+    _validate_check_names(columns)
     _validate_composite_unique(composite_unique)
     _validate_shape_constraints(min_rows, max_rows, exact_rows)
 
@@ -266,6 +295,7 @@ def df_in(
         columns = name
         name = None
 
+    _validate_check_names(columns)
     _validate_composite_unique(composite_unique)
     _validate_shape_constraints(min_rows, max_rows, exact_rows)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -226,7 +226,9 @@ Available built-in checks for the `checks` parameter:
 | `str_contains`   | `str`      | String contains substring  |
 | `str_length`     | `(lo, hi)` | String length in range     |
 
-Custom checks are also supported by passing a callable as the check value.
+Custom checks are also supported by passing a callable as the check value. A callable may use any
+name; a non-callable value must name one of the built-in checks above, and a name that matches
+neither is rejected when the decorator is applied rather than on the first call.
 
 `str_regex` applies your pattern as written: it matches anywhere in the value unless you anchor it
 yourself. Use `r"^\d+"` to require a match at the start and `r"^\d+$"` to require a full match.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,6 +1,6 @@
 """Tests for value checks."""
 
-from typing import Any
+from typing import Any, ClassVar
 
 import narwhals as nw
 import pandas as pd
@@ -8,7 +8,7 @@ import polars as pl
 import pyarrow as pa
 import pytest
 
-from daffy.checks import apply_check, validate_checks
+from daffy.checks import BUILTIN_CHECK_NAMES, apply_check, validate_checks
 
 
 def numeric_with_null(backend: str) -> Any:
@@ -485,3 +485,44 @@ class TestValidateChecks:
         violations = validate_checks(nws, "score", {"gt": 0, "lt": 100})
         assert len(violations) == 1
         assert violations[0][1] == "lt"
+
+
+class TestBuiltinCheckNamesStayInSync:
+    """The names offered to callers must be exactly the names apply_check implements.
+
+    Decoration-time validation rejects unknown names using BUILTIN_CHECK_NAMES, so a
+    name that drifts out of apply_check would be accepted and then fail on first call -
+    or worse, a working check would be rejected before it ever ran.
+    """
+
+    SAMPLE_VALUES: ClassVar[dict[str, Any]] = {
+        "gt": 0,
+        "ge": 0,
+        "lt": 100,
+        "le": 100,
+        "between": (0, 100),
+        "eq": 1,
+        "ne": 9,
+        "isin": [1, 2, 3],
+        "notin": [9],
+        "notnull": True,
+        "str_regex": r"\d+",
+        "str_startswith": "1",
+        "str_endswith": "1",
+        "str_contains": "1",
+        "str_length": (1, 5),
+    }
+
+    def test_sample_values_cover_every_advertised_check(self) -> None:
+        assert set(self.SAMPLE_VALUES) == BUILTIN_CHECK_NAMES
+
+    @pytest.mark.parametrize("check_name", sorted(BUILTIN_CHECK_NAMES))
+    def test_every_advertised_check_is_implemented(self, check_name: str) -> None:
+        series = pd.Series(["1", "2", "3"]) if check_name.startswith("str_") else pd.Series([1, 2, 3])
+
+        apply_check(series, check_name, self.SAMPLE_VALUES[check_name])
+
+    def test_a_name_outside_the_set_is_rejected(self) -> None:
+        assert "gtt" not in BUILTIN_CHECK_NAMES
+        with pytest.raises(ValueError, match="Unknown check"):
+            apply_check(pd.Series([1]), "gtt", 0)

--- a/tests/test_value_checks_integration.py
+++ b/tests/test_value_checks_integration.py
@@ -309,3 +309,43 @@ class TestErrorMessages:
         df = pd.DataFrame({"a": [-1], "b": [-2]})
         with pytest.raises(AssertionError, match="Check violations"):
             process(df)
+
+
+class TestCheckNamesValidatedAtDecoration:
+    """A misspelled built-in check fails when the decorator is applied, not on first call."""
+
+    @pytest.mark.parametrize("decorator", [df_in, df_out])
+    def test_unknown_check_name_rejected(self, decorator: Any) -> None:
+        with pytest.raises(ValueError, match="Unknown check 'gtt' for column 'price'"):
+            decorator(columns={"price": {"checks": {"gtt": 0}}})
+
+    def test_error_lists_the_valid_names(self) -> None:
+        with pytest.raises(ValueError, match="str_startswith"):
+            df_in(columns={"price": {"checks": {"startswith": "x"}}})
+
+    def test_rejected_before_the_function_is_ever_called(self) -> None:
+        with pytest.raises(ValueError, match="Unknown check"):
+
+            @df_in(columns={"price": {"checks": {"greater_than": 0}}})
+            def process(df: pd.DataFrame) -> pd.DataFrame:  # pragma: no cover
+                return df
+
+    def test_shorthand_positional_spec_is_checked_too(self) -> None:
+        with pytest.raises(ValueError, match="Unknown check 'gtt'"):
+            df_in({"price": {"checks": {"gtt": 0}}})
+
+    def test_custom_callable_may_use_any_name(self) -> None:
+        @df_in(columns={"price": {"checks": {"no_outliers": lambda s: s > 0}}})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        df = pd.DataFrame({"price": [1, 2, 3]})
+        assert to_list(process(df)["price"]) == [1, 2, 3]
+
+    @pytest.mark.parametrize("columns", [["price"], {"price": "int64"}, {"price": {"dtype": "int64"}}, None])
+    def test_specs_without_checks_are_untouched(self, columns: Any) -> None:
+        df_in(columns=columns)
+
+    def test_non_dict_checks_left_to_runtime(self) -> None:
+        """Malformed `checks` is a spec-shape problem, handled by strict_specs, not here."""
+        df_in(columns={"price": {"checks": "nonsense"}})


### PR DESCRIPTION
`{"checks": {"gtt": 0}}` used to decorate cleanly and only fail when the function was first called with data — so the error landed far from the typo, and never appeared at all for a path that was not exercised. Shape constraints and `composite_unique` were already validated at decoration time; check names now are too.

## Custom checks are not caught in the crossfire

The concern with validating names is that daffy mixes built-ins with user callables, and a custom check can be called anything. The rule here mirrors `apply_check` exactly rather than inventing a second one:

- **callable value** → custom check, any name, never validated
- **non-callable value** → must name a built-in, otherwise `ValueError` at decoration

That is the same branch `apply_check` takes at runtime, so nothing can be accepted at decoration and then rejected on the first call.

```python
@df_in({"price": {"checks": {"no_outliers": lambda s: s < s.mean() * 10}}})  # fine, any name
@df_in({"price": {"checks": {"gtt": 0}}})                                    # ValueError, lists valid names
```

Specs without checks, list specs, dtype-only dicts, and the `@df_in({...})` positional shorthand are all covered by tests. A malformed non-dict `checks` value is left alone — that is a spec-shape problem belonging to `strict_specs`, not to name validation.

## Drift guard

Decoration-time validation reads `BUILTIN_CHECK_NAMES` (from the `CheckName` literal) while runtime dispatch reads `apply_check`'s own table. They agree today, but nothing enforced it, and a divergence would either reject a working check before it runs or accept a name that fails later.

The new guard calls every advertised name through `apply_check` with a representative value and asserts the sample set covers the advertised set exactly. Verified by adding a `str_titlecase` entry to the literal with no implementation: 3 tests fail.

775 tests, coverage 99.4%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid built-in value-check names are now rejected when decorators are applied, with a list of valid names.
  * Custom callable checks remain supported with unrestricted names.
  * Validation behavior is consistent for both input and output checks, including shorthand syntax.

* **Documentation**
  * Clarified the rules for built-in and custom value checks and when invalid names are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->