### PR TITLE
Daffy 3.1.0: fix four silent-validation bugs found by a six-angle audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 3.1.0
+
+A six-angle audit of the codebase found four bugs where validation silently did not happen
+or crashed outside daffy's error contract. Everything here either closes one of those, or
+makes a failure say what went wrong.
+
+**Migrating:** column specs that were quietly doing nothing now raise when the decorator is
+applied — a misspelled constraint (`{"nullabel": False}`), a non-boolean `nullable`/`unique`/
+`required`, or a check whose dtype it cannot mean anything on. Each one was a guard that
+never ran, so the error is reporting a bug you already had.
+
+### Fixed
+
+- **Overlapping column specs no longer drop a constraint.** `{"r/^price/": {"checks": {"gt": 0}}, "price_eur": {"checks": {"lt": 100}}}` applied only one of the two checks, and which one depended on dict insertion order. Every spec that matches a column now applies. The same overlap crashed `nullable` and `unique` with a Narwhals `DuplicateError` rather than an `AssertionError`.
+- **`strict=True` is no longer ignored when the column spec is empty.** `@df_in([], strict=True)` permitted any frame; an empty spec now means no columns are permitted.
+- **Duplicate column names no longer escape as a Narwhals error.** `@df_in`/`@df_out` report them as an `AssertionError`, and `@df_log` — which only logs — warns and leaves the function working instead of raising.
+- **A check that cannot mean anything on a column's dtype is now rejected on every backend.** An ordering check on a string column, or a `str_*` check on a non-string column, previously raised a raw backend error on Pandas and PyArrow while Polars compared lexicographically and reported a violation that looked real. Other backend failures during a check are wrapped with the check name, dtype and value.
+- **Row validation no longer understates catastrophic failures.** With early termination, 10,000 failing rows out of 10,000 reported "at least 6 … and 1 more row(s)". It now says counting stopped rather than inventing a remainder.
+- **The decorators no longer erase type information.** They returned `Callable[..., T]`, which silently disabled argument type checking at every call site of a decorated function. `ColumnsDef` also rejected any spec that was not an inline literal, including `dict[str, ColumnConstraints]`.
+- Errors past a `*args` boundary named the wrong parameter, and wrong-type errors did not name the function.
 
 ### Changed
 
-- Misspelled built-in check names are now rejected when the decorator is applied instead of on the first call with data, so `{"checks": {"gtt": 0}}` fails at import time with the list of valid names. Custom checks are unaffected: a callable check value may carry any name, exactly as at runtime.
+- **Unusable column specs are rejected when the decorator is applied.** Misspelled constraint names, non-boolean `nullable`/`unique`/`required` values, and misspelled built-in check names all used to be accepted and then do nothing. Custom checks are unaffected: a callable check value may carry any name.
+
+### Performance
+
+- Another ~15% off per-call overhead (`@df_in(columns=...)` ~41µs → ~38µs) by removing `SkippableValidator`, a protocol with no implementations that cost a `runtime_checkable` `isinstance` per validator per call.
+
+### Documentation
+
+- Corrected five quoted error/log outputs that no longer matched what daffy prints, fixed three README documentation links that 404'd, and documented `strict_specs`, the three config keys missing from the API reference, `ColumnConstraints`, and the fact that config discovery is relative to the working directory.
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,11 @@ never ran, so the error is reporting a bug you already had.
 
 ### Performance
 
-- Another ~15% off per-call overhead (`@df_in(columns=...)` ~41µs → ~38µs) by removing `SkippableValidator`, a protocol with no implementations that cost a `runtime_checkable` `isinstance` per validator per call.
+- Another ~7% off per-call overhead (`@df_in(columns=...)` ~41µs → ~38µs, measured on a 100-row Pandas frame) by removing `SkippableValidator`, a protocol with no implementations that cost a `runtime_checkable` `isinstance` per validator per call. Total since 2.8.0 is ~212µs → ~38µs.
+
+### Removed
+
+- `daffy.validators.SkippableValidator` and the `should_skip` hook. Nothing in daffy implemented it, and `ValidationPipeline` no longer calls it. It is removed rather than deprecated deliberately: a compatibility shim would keep `from daffy.validators import SkippableValidator` working while silently never skipping anything, which is the failure mode this release exists to remove. Validators already express "nothing to do" by returning `[]`, and the builder omits validators with no work.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ strict = true
 
 Full documentation available at **[daffy.readthedocs.io](https://daffy.readthedocs.io)**
 
-- [Getting Started](https://daffy.readthedocs.io/getting-started/) — quick introduction
-- [Usage Guide](https://daffy.readthedocs.io/usage/) — comprehensive reference
-- [API Reference](https://daffy.readthedocs.io/api/) — decorator signatures
+- [Getting Started](https://daffy.readthedocs.io/en/latest/getting-started/) — quick introduction
+- [Usage Guide](https://daffy.readthedocs.io/en/latest/usage/) — comprehensive reference
+- [API Reference](https://daffy.readthedocs.io/en/latest/api/) — decorator signatures
 - [Changelog](https://github.com/vertti/daffy/blob/master/CHANGELOG.md) — version history
 
 ---

--- a/daffy/checks.py
+++ b/daffy/checks.py
@@ -53,6 +53,37 @@ def _failing_mask(valid_mask: nw.Series[Any]) -> nw.Series[Any]:
     return ~valid_mask.fill_null(True).cast(nw.Boolean())
 
 
+_STRING_ONLY_CHECKS = frozenset({"str_regex", "str_startswith", "str_endswith", "str_contains", "str_length"})
+_ORDERING_CHECKS = frozenset({"gt", "ge", "lt", "le", "between"})
+
+
+def _assert_dtype_fits_check(nws: nw.Series[Any], check_name: str) -> None:
+    """Reject checks that cannot mean what the caller intended on this column's dtype.
+
+    Without this, backends disagree: Pandas and PyArrow raise their own errors, while
+    Polars coerces the bound to a string and compares lexicographically, reporting "10"
+    as failing `gt: 5` in a message indistinguishable from a real violation.
+    """
+    is_string = nws.dtype == nw.String
+    if check_name in _STRING_ONLY_CHECKS and not is_string:
+        raise ValueError(f"Check '{check_name}' needs a string column, but this column is {nws.dtype}")
+    # Only the string side is ambiguous: Pandas reports an all-null object column as
+    # String, so a comparison there is a false alarm rather than a real mismatch.
+    if check_name in _ORDERING_CHECKS and is_string and not _has_no_values(nws):
+        raise ValueError(
+            f"Check '{check_name}' compares order, which is ambiguous on a string column. "
+            f"Convert the column to a number, or use str_length for length constraints."
+        )
+
+
+def _has_no_values(nws: nw.Series[Any]) -> bool:
+    """Report whether the column is empty or entirely null, leaving its dtype uninformative.
+
+    Only computed when a check is about to be rejected, to keep it off the hot path.
+    """
+    return len(nws) == 0 or int(nws.is_null().sum()) == len(nws)
+
+
 def _evaluate_mask(nws: nw.Series[Any], fail_mask: nw.Series[Any], max_samples: int) -> tuple[int, list[Any]]:
     """Count failures and sample failing values from a boolean mask (True = failing)."""
     nw_mask = fail_mask.fill_null(False)
@@ -122,7 +153,15 @@ def apply_check(series_or_nws: Any, check_name: str, check_value: Any, max_sampl
     if check_name not in check_masks:
         raise ValueError(f"Unknown check: {check_name}")
 
-    return _evaluate_mask(nws, check_masks[check_name](), max_samples)
+    _assert_dtype_fits_check(nws, check_name)
+    try:
+        fail_mask = check_masks[check_name]()
+    except Exception as e:
+        raise ValueError(
+            f"Check '{check_name}' could not run on a {nws.dtype} column with value {check_value!r}: {e}"
+        ) from e
+
+    return _evaluate_mask(nws, fail_mask, max_samples)
 
 
 def validate_checks(

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -213,7 +213,7 @@ def df_out(
         @wraps(func)
         def wrapper(*args: OutParams.args, **kwargs: OutParams.kwargs) -> IntoDataFrameT:
             result = func(*args, **kwargs)
-            nw_df = assert_is_dataframe(result, "return type")
+            nw_df = assert_is_dataframe(result, "return type", func_name=getattr(func, "__name__", ""))
             _run_validations(
                 result,
                 getattr(func, "__name__", "<unknown>"),
@@ -333,7 +333,7 @@ def df_in(
         @wraps(func)
         def wrapper(*args: InParams.args, **kwargs: InParams.kwargs) -> InReturnT:
             df, param_name, resolved_nw_df = resolver.resolve(name, *args, **kwargs)
-            nw_df = assert_is_dataframe(df, "parameter type", resolved_nw_df)
+            nw_df = assert_is_dataframe(df, "parameter type", resolved_nw_df, func_name=getattr(func, "__name__", ""))
             _run_validations(
                 df,
                 getattr(func, "__name__", "<unknown>"),

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from functools import wraps
-from typing import TYPE_CHECKING, Any, TypeVar, overload
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -87,7 +87,12 @@ def _validate_shape_constraints(
         raise ValueError(f"min_rows ({min_rows}) cannot be greater than max_rows ({max_rows})")
 
 
-# Type variables for preserving return types
+# Type variables for preserving signatures. ParamSpec keeps the decorated function's
+# parameters visible to type checkers - with a bare `...` every call site of a
+# decorated function silently loses argument checking.
+LogParams = ParamSpec("LogParams")
+InParams = ParamSpec("InParams")
+OutParams = ParamSpec("OutParams")
 LogReturnT = TypeVar("LogReturnT")  # Return type for df_log
 InReturnT = TypeVar("InReturnT")  # Return type for df_in
 
@@ -144,7 +149,7 @@ def df_out(
     max_rows: int | None = None,
     exact_rows: int | None = None,
     allow_empty: bool | None = None,
-) -> Callable[[Callable[..., IntoDataFrameT]], Callable[..., IntoDataFrameT]]:
+) -> Callable[[Callable[OutParams, IntoDataFrameT]], Callable[OutParams, IntoDataFrameT]]:
     """Decorate a function that returns a DataFrame (Pandas, Polars, Modin, or PyArrow).
 
     Document the return value of a function. The return value will be validated in runtime.
@@ -181,9 +186,9 @@ def df_out(
     _validate_composite_unique(composite_unique)
     _validate_shape_constraints(min_rows, max_rows, exact_rows)
 
-    def wrapper_df_out(func: Callable[..., IntoDataFrameT]) -> Callable[..., IntoDataFrameT]:
+    def wrapper_df_out(func: Callable[OutParams, IntoDataFrameT]) -> Callable[OutParams, IntoDataFrameT]:
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> IntoDataFrameT:
+        def wrapper(*args: OutParams.args, **kwargs: OutParams.kwargs) -> IntoDataFrameT:
             result = func(*args, **kwargs)
             nw_df = assert_is_dataframe(result, "return type")
             _run_validations(
@@ -222,7 +227,7 @@ def df_in(
     max_rows: int | None = ...,
     exact_rows: int | None = ...,
     allow_empty: bool | None = ...,
-) -> Callable[[Callable[..., InReturnT]], Callable[..., InReturnT]]: ...
+) -> Callable[[Callable[InParams, InReturnT]], Callable[InParams, InReturnT]]: ...
 
 
 @overload
@@ -237,7 +242,7 @@ def df_in(
     max_rows: int | None = ...,
     exact_rows: int | None = ...,
     allow_empty: bool | None = ...,
-) -> Callable[[Callable[..., InReturnT]], Callable[..., InReturnT]]: ...
+) -> Callable[[Callable[InParams, InReturnT]], Callable[InParams, InReturnT]]: ...
 
 
 def df_in(
@@ -251,7 +256,7 @@ def df_in(
     max_rows: int | None = None,
     exact_rows: int | None = None,
     allow_empty: bool | None = None,
-) -> Callable[[Callable[..., InReturnT]], Callable[..., InReturnT]]:
+) -> Callable[[Callable[InParams, InReturnT]], Callable[InParams, InReturnT]]:
     """Decorate a function parameter that is a DataFrame (Pandas, Polars, Modin, or PyArrow).
 
     Document the contents of an input parameter. The parameter will be validated in runtime.
@@ -299,11 +304,11 @@ def df_in(
     _validate_composite_unique(composite_unique)
     _validate_shape_constraints(min_rows, max_rows, exact_rows)
 
-    def wrapper_df_in(func: Callable[..., InReturnT]) -> Callable[..., InReturnT]:
+    def wrapper_df_in(func: Callable[InParams, InReturnT]) -> Callable[InParams, InReturnT]:
         resolver = ParameterResolver(func)
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> InReturnT:
+        def wrapper(*args: InParams.args, **kwargs: InParams.kwargs) -> InReturnT:
             df, param_name, resolved_nw_df = resolver.resolve(name, *args, **kwargs)
             nw_df = assert_is_dataframe(df, "parameter type", resolved_nw_df)
             _run_validations(
@@ -331,7 +336,7 @@ def df_in(
 
 def df_log(
     level: int = logging.DEBUG, include_dtypes: bool = False
-) -> Callable[[Callable[..., LogReturnT]], Callable[..., LogReturnT]]:
+) -> Callable[[Callable[LogParams, LogReturnT]], Callable[LogParams, LogReturnT]]:
     """Decorate a function that consumes or produces a Pandas DataFrame or both.
 
     Logs the columns of the consumed and/or produced DataFrame.
@@ -345,11 +350,11 @@ def df_log(
 
     """
 
-    def wrapper_df_log(func: Callable[..., LogReturnT]) -> Callable[..., LogReturnT]:
+    def wrapper_df_log(func: Callable[LogParams, LogReturnT]) -> Callable[LogParams, LogReturnT]:
         resolver = ParameterResolver(func)
 
         @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> LogReturnT:
+        def wrapper(*args: LogParams.args, **kwargs: LogParams.kwargs) -> LogReturnT:
             func_name = getattr(func, "__name__", "<unknown>")
             df, _, _ = resolver.resolve(None, *args, **kwargs)
             log_dataframe_input(level, func_name, df, include_dtypes)

--- a/daffy/decorators.py
+++ b/daffy/decorators.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from functools import wraps
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
 
@@ -24,6 +25,7 @@ from daffy.utils import (
 )
 from daffy.validators.builder import build_validation_pipeline
 from daffy.validators.context import ValidationContext
+from daffy.validators.spec_parser import assert_known_constraints
 
 
 def _validate_composite_unique(composite_unique: list[list[str]] | None) -> None:
@@ -44,31 +46,52 @@ def _validate_composite_unique(composite_unique: list[list[str]] | None) -> None
                 raise TypeError(f"composite_unique[{i}][{j}] must be a string, got {type(col).__name__}")
 
 
-def _validate_check_names(columns: ColumnsDef) -> None:
-    """Reject unknown built-in check names at decoration time.
+_BOOLEAN_CONSTRAINTS = ("nullable", "unique", "required")
+
+
+def _validate_check_names(column: str, checks: Any) -> None:
+    """Reject unknown built-in check names.
 
     Mirrors `apply_check`: a callable check value is a custom check and may carry any
-    name, so only non-callable values are matched against the built-ins. Without this,
-    a typo like `{"checks": {"gtt": 0}}` decorates cleanly and only fails on the first
-    call with data.
+    name, so only non-callable values are matched against the built-ins.
     """
-    if not isinstance(columns, dict):
+    if not isinstance(checks, dict):
+        return
+
+    for check_name, check_value in checks.items():
+        if callable(check_value) or check_name in BUILTIN_CHECK_NAMES:
+            continue
+        valid = ", ".join(sorted(BUILTIN_CHECK_NAMES))
+        raise ValueError(
+            f"Unknown check '{check_name}' for column '{column}'. "
+            f"Pass a callable to define a custom check, or use one of: {valid}"
+        )
+
+
+def _validate_column_spec(columns: ColumnsDef) -> None:
+    """Reject unusable column specs at decoration time.
+
+    Everything here used to be accepted and then quietly do nothing, which is the worst
+    outcome for a validation library: the decorator reads as a guarantee while no
+    validation runs. Catching it at decoration puts the error next to the mistake.
+    """
+    if not isinstance(columns, Mapping):
         return
 
     for column, spec in columns.items():
         if not isinstance(spec, dict):
             continue
-        checks = spec.get("checks")
-        if not isinstance(checks, dict):
-            continue
-        for check_name, check_value in checks.items():
-            if callable(check_value) or check_name in BUILTIN_CHECK_NAMES:
-                continue
-            valid = ", ".join(sorted(BUILTIN_CHECK_NAMES))
-            raise ValueError(
-                f"Unknown check '{check_name}' for column '{column}'. "
-                f"Pass a callable to define a custom check, or use one of: {valid}"
-            )
+
+        assert_known_constraints(str(column), spec)
+
+        for key in _BOOLEAN_CONSTRAINTS:
+            if key in spec and not isinstance(spec[key], bool):
+                raise TypeError(
+                    f"Constraint '{key}' for column '{column}' must be True or False, "
+                    f"got {type(spec[key]).__name__}: {spec[key]!r}"
+                )
+
+        _validate_check_names(str(column), spec.get("checks"))
 
 
 def _validate_shape_constraints(
@@ -182,7 +205,7 @@ def df_out(
         Callable: Decorated function with preserved DataFrame return type
 
     """
-    _validate_check_names(columns)
+    _validate_column_spec(columns)
     _validate_composite_unique(composite_unique)
     _validate_shape_constraints(min_rows, max_rows, exact_rows)
 
@@ -300,7 +323,7 @@ def df_in(
         columns = name
         name = None
 
-    _validate_check_names(columns)
+    _validate_column_spec(columns)
     _validate_composite_unique(composite_unique)
     _validate_shape_constraints(min_rows, max_rows, exact_rows)
 

--- a/daffy/narwhals_compat.py
+++ b/daffy/narwhals_compat.py
@@ -5,16 +5,38 @@ from __future__ import annotations
 from typing import Any
 
 import narwhals as nw
+from narwhals.exceptions import NarwhalsError
+
+
+class UnsupportedDataFrameError(Exception):
+    """A supported DataFrame type that Narwhals cannot work with, e.g. duplicate column names."""
 
 
 def to_nw_dataframe(obj: Any) -> Any | None:
-    """Convert to a Narwhals DataFrame, or return None if the object is not one."""
+    """Convert to a Narwhals DataFrame, or return None if the object is not one.
+
+    Raises:
+        UnsupportedDataFrameError: If the object is a DataFrame that Narwhals rejects.
+            Duplicate column names are the common case, and they arrive as
+            `DuplicateError`, which is a ValueError - not the TypeError raised for
+            "this is not a DataFrame at all".
+
+    """
     try:
         return nw.from_native(obj, eager_only=True)
     except TypeError:
         return None
+    except NarwhalsError as e:
+        raise UnsupportedDataFrameError(str(e)) from e
 
 
 def is_supported_dataframe(obj: Any) -> bool:
-    """Check if object is a supported eager DataFrame type."""
-    return to_nw_dataframe(obj) is not None
+    """Check if object is a supported eager DataFrame type.
+
+    A DataFrame Narwhals cannot work with is still a DataFrame, so this answers True
+    for it; converting is what surfaces the problem.
+    """
+    try:
+        return to_nw_dataframe(obj) is not None
+    except UnsupportedDataFrameError:
+        return True

--- a/daffy/utils.py
+++ b/daffy/utils.py
@@ -15,13 +15,14 @@ if TYPE_CHECKING:
 _POSITIONAL_KINDS = (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
 
 
-def assert_is_dataframe(obj: Any, context: str, nw_df: Any = None) -> Any:
+def assert_is_dataframe(obj: Any, context: str, nw_df: Any = None, func_name: str = "") -> Any:
     """Verify that an object is a supported DataFrame (Pandas, Polars, Modin, or PyArrow).
 
     Args:
         obj: Object to validate
         context: Context string for the error message (e.g., "parameter type", "return type")
         nw_df: Narwhals view of obj when the caller already has one, to skip re-converting
+        func_name: Decorated function, so the message says where the problem is
 
     Returns:
         The Narwhals view of the DataFrame, so callers do not convert it a second time.
@@ -30,14 +31,17 @@ def assert_is_dataframe(obj: Any, context: str, nw_df: Any = None) -> Any:
         AssertionError: If obj is not a DataFrame
 
     """
+    where = f" in function '{func_name}'" if func_name else ""
     if nw_df is None:
         try:
             nw_df = to_nw_dataframe(obj)
         except UnsupportedDataFrameError as e:
-            raise AssertionError(f"Cannot validate this DataFrame ({context}): {e}") from None
+            raise AssertionError(f"Cannot validate this DataFrame ({context}{where}): {e}") from None
     if nw_df is None:
         libs_str = " or ".join(get_available_library_names())
-        raise AssertionError(f"Wrong {context}. Expected {libs_str} DataFrame, got {type(obj).__name__} instead.")
+        raise AssertionError(
+            f"Wrong {context}{where}. Expected {libs_str} DataFrame, got {type(obj).__name__} instead."
+        )
     return nw_df
 
 
@@ -71,7 +75,6 @@ class ParameterResolver:
         self.param_defaults = [p.default for p in self.params]
 
         self.var_pos_name = next((p.name for p in self.params if p.kind is inspect.Parameter.VAR_POSITIONAL), None)
-        self.var_kw_name = next((p.name for p in self.params if p.kind is inspect.Parameter.VAR_KEYWORD), None)
 
     def resolve(self, name: str | None, *args: Any, **kwargs: Any) -> tuple[Any, str | None, Any]:  # noqa: C901, PLR0911, PLR0912
         """Extract a parameter value and its name from function arguments.

--- a/daffy/utils.py
+++ b/daffy/utils.py
@@ -6,13 +6,13 @@ import inspect
 import logging
 from typing import TYPE_CHECKING, Any
 
-import narwhals as nw
-
 from daffy.dataframe_types import get_available_library_names
-from daffy.narwhals_compat import is_supported_dataframe, to_nw_dataframe
+from daffy.narwhals_compat import UnsupportedDataFrameError, is_supported_dataframe, to_nw_dataframe
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+_POSITIONAL_KINDS = (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
 
 
 def assert_is_dataframe(obj: Any, context: str, nw_df: Any = None) -> Any:
@@ -31,11 +31,27 @@ def assert_is_dataframe(obj: Any, context: str, nw_df: Any = None) -> Any:
 
     """
     if nw_df is None:
-        nw_df = to_nw_dataframe(obj)
+        try:
+            nw_df = to_nw_dataframe(obj)
+        except UnsupportedDataFrameError as e:
+            raise AssertionError(f"Cannot validate this DataFrame ({context}): {e}") from None
     if nw_df is None:
         libs_str = " or ".join(get_available_library_names())
         raise AssertionError(f"Wrong {context}. Expected {libs_str} DataFrame, got {type(obj).__name__} instead.")
     return nw_df
+
+
+def _find_dataframe(obj: Any) -> tuple[Any, bool]:
+    """Return (Narwhals view or None, whether obj is a DataFrame at all).
+
+    A DataFrame Narwhals cannot convert counts as found, so the caller stops searching
+    and lets `assert_is_dataframe` report why it is unusable.
+    """
+    try:
+        nw_df = to_nw_dataframe(obj)
+    except UnsupportedDataFrameError:
+        return None, True
+    return nw_df, nw_df is not None
 
 
 class ParameterResolver:
@@ -45,6 +61,10 @@ class ParameterResolver:
         sig = inspect.signature(func)
         self.params = list(sig.parameters.values())
         self.param_names = [p.name for p in self.params]
+
+        # Only these can be filled positionally. Indexing param_names by position would
+        # run past the *args slot into keyword-only names and report the wrong parameter.
+        self.positional_names = [p.name for p in self.params if p.kind in _POSITIONAL_KINDS]
 
         # Precompute lists for faster lookup during resolve
         self.param_kinds = [p.kind for p in self.params]
@@ -63,16 +83,16 @@ class ParameterResolver:
         if not name:
             # 1. Search positional arguments
             for i, arg in enumerate(args):
-                nw_df = to_nw_dataframe(arg)
-                if nw_df is not None:
-                    if i < len(self.param_names):
-                        return arg, self.param_names[i], nw_df
+                nw_df, is_frame = _find_dataframe(arg)
+                if is_frame:
+                    if i < len(self.positional_names):
+                        return arg, self.positional_names[i], nw_df
                     return arg, self.var_pos_name, nw_df
 
             # 2. Search keyword arguments
             for kw_name, kw_val in kwargs.items():
-                nw_df = to_nw_dataframe(kw_val)
-                if nw_df is not None:
+                nw_df, is_frame = _find_dataframe(kw_val)
+                if is_frame:
                     # If it's explicitly in the signature, return that name.
                     # Otherwise, if it's passed as kwargs but VAR_KEYWORD exists, return kw_name.
                     return kw_val, kw_name, nw_df
@@ -115,7 +135,9 @@ class ParameterResolver:
 
 
 def describe_dataframe(df: Any, include_dtypes: bool = False) -> str:
-    nw_df = nw.from_native(df, eager_only=True)
+    nw_df = to_nw_dataframe(df)
+    if nw_df is None:
+        raise UnsupportedDataFrameError(f"not a supported DataFrame, got {type(df).__name__}")
     result = f"columns: {nw_df.columns}"
     if include_dtypes:
         result += f" with dtypes {list(nw_df.schema.values())}"
@@ -123,8 +145,15 @@ def describe_dataframe(df: Any, include_dtypes: bool = False) -> str:
 
 
 def _log_dataframe(level: int, func_name: str, df: Any, include_dtypes: bool, context: str) -> None:
-    if is_supported_dataframe(df):
-        logging.log(level, f"Function {func_name} {context}: {describe_dataframe(df, include_dtypes)}")  # noqa: LOG015, G004
+    if not is_supported_dataframe(df):
+        return
+    try:
+        description = describe_dataframe(df, include_dtypes)
+    except UnsupportedDataFrameError as e:
+        # df_log only logs. A frame it cannot describe must not break the function.
+        logging.warning(f"Function {func_name} {context}, but it could not be described: {e}")  # noqa: LOG015, G004
+        return
+    logging.log(level, f"Function {func_name} {context}: {description}")  # noqa: LOG015, G004
 
 
 def log_dataframe_input(level: int, func_name: str, df: Any, include_dtypes: bool) -> None:

--- a/daffy/validation.py
+++ b/daffy/validation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, TypeAlias, TypedDict
 
 from daffy.patterns import RegexColumnDef
@@ -22,4 +22,8 @@ class ColumnConstraints(TypedDict, total=False):
     checks: dict[str, Any]
 
 
-ColumnsDef: TypeAlias = Sequence[str | RegexColumnDef] | dict[str | RegexColumnDef, Any] | None
+# Mapping rather than dict, and str keys only: dict keys are invariant, so a
+# dict[str, ...] built elsewhere - including dict[str, ColumnConstraints] - would not be
+# assignable and only inline literals would type-check. Regex specs are written as
+# "r/pattern/" strings; RegexColumnDef is the compiled internal form.
+ColumnsDef: TypeAlias = Sequence[str | RegexColumnDef] | Mapping[str, Any] | None

--- a/daffy/validators/__init__.py
+++ b/daffy/validators/__init__.py
@@ -1,6 +1,6 @@
 """Validation pipeline for DataFrame validation."""
 
-from daffy.validators.base import SkippableValidator, Validator
+from daffy.validators.base import Validator
 from daffy.validators.builder import build_validation_pipeline
 from daffy.validators.checks import ChecksValidator
 from daffy.validators.columns import ColumnsExistValidator, DtypeValidator, NullableValidator, StrictModeValidator
@@ -20,7 +20,6 @@ __all__ = [
     "ParsedColumnSpec",
     "RowValidator",
     "ShapeValidator",
-    "SkippableValidator",
     "StrictModeValidator",
     "UniqueValidator",
     "ValidationContext",

--- a/daffy/validators/base.py
+++ b/daffy/validators/base.py
@@ -21,16 +21,3 @@ class Validator(Protocol):
     def validate(self, ctx: ValidationContext) -> list[str]:
         """Validate the DataFrame in context. Return list of error messages."""
         ...
-
-
-@runtime_checkable
-class SkippableValidator(Protocol):
-    """Validator that can be skipped based on context."""
-
-    def should_skip(self, ctx: ValidationContext) -> bool:
-        """Return True to skip this validator entirely."""
-        ...
-
-    def validate(self, ctx: ValidationContext) -> list[str]:
-        """Validate the DataFrame in context. Return list of error messages."""
-        ...

--- a/daffy/validators/builder.py
+++ b/daffy/validators/builder.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from daffy.patterns import compile_regex_pattern, is_regex_string, match_column_with_regex
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
 from daffy.validators.checks import ChecksValidator
 from daffy.validators.columns import ColumnsExistValidator, DtypeValidator, NullableValidator, StrictModeValidator
@@ -71,7 +71,7 @@ def _expand_checks(specs: dict[str, dict[str, Any]], resolved: dict[str, list[st
 
 
 def build_validation_pipeline(  # noqa: C901
-    columns: Sequence[Any] | dict[Any, Any] | None,
+    columns: Sequence[Any] | Mapping[str, Any] | None,
     strict: bool,
     strict_specs: bool,
     lazy: bool,

--- a/daffy/validators/builder.py
+++ b/daffy/validators/builder.py
@@ -37,19 +37,37 @@ def _resolve_columns(specs: list[str], df_columns: list[str]) -> tuple[list[str]
     return missing, resolved
 
 
-def _expand_specs(specs: dict[str, Any] | list[str], resolved: dict[str, list[str]]) -> dict[str, Any] | list[str]:
-    """Expand column specs to actual column names using resolution map."""
-    if isinstance(specs, dict):
-        result: dict[str, Any] = {}
-        for spec, value in specs.items():
-            for col in resolved.get(spec, []):
-                result[col] = value
-        return result
+def _expand_columns(specs: list[str], resolved: dict[str, list[str]]) -> list[str]:
+    """Expand specs to the columns they matched, without repeating a column.
 
-    result_list: list[str] = []
-    for spec in specs:
-        result_list.extend(resolved.get(spec, []))
-    return result_list
+    Two specs can resolve to the same column - `"r/^price/"` and `"price_eur"` both
+    match `price_eur`. Emitting it twice makes validators build duplicate expressions,
+    which the backends reject.
+    """
+    return list(dict.fromkeys(col for spec in specs for col in resolved.get(spec, [])))
+
+
+def _expand_dtypes(specs: dict[str, Any], resolved: dict[str, list[str]]) -> dict[str, Any]:
+    """Expand dtype specs. The most specific spec for a column wins."""
+    result: dict[str, Any] = {}
+    for spec, dtype in specs.items():
+        for col in resolved.get(spec, []):
+            if col not in result or not is_regex_string(spec):
+                result[col] = dtype
+    return result
+
+
+def _expand_checks(specs: dict[str, dict[str, Any]], resolved: dict[str, list[str]]) -> dict[str, dict[str, Any]]:
+    """Expand check specs, merging every spec that matched a column.
+
+    `{"r/^price/": {"checks": {"gt": 0}}, "price_eur": {"checks": {"lt": 100}}}` means
+    both checks apply to `price_eur`; keeping only one would silently stop validating.
+    """
+    result: dict[str, dict[str, Any]] = {}
+    for spec, checks in specs.items():
+        for col in resolved.get(spec, []):
+            result[col] = {**result.get(col, {}), **checks}
+    return result
 
 
 def build_validation_pipeline(  # noqa: C901
@@ -74,7 +92,7 @@ def build_validation_pipeline(  # noqa: C901
             ShapeValidator(min_rows=min_rows, max_rows=max_rows, exact_rows=exact_rows, allow_empty=allow_empty)
         )
 
-    if columns:
+    if columns is not None:
         spec = parse_column_spec(columns, strict_specs=strict_specs)
 
         missing_required, resolved_required = _resolve_columns(spec.required_columns, df_columns)
@@ -84,15 +102,14 @@ def build_validation_pipeline(  # noqa: C901
         _, resolved_optional = _resolve_columns(spec.optional_columns, df_columns)
         resolved_all = {**resolved_required, **resolved_optional}
 
-        validators = [
-            (spec.dtype_constraints, DtypeValidator),
-            (spec.non_nullable_columns, NullableValidator),
-            (spec.unique_columns, UniqueValidator),
-            (spec.checks_by_column, ChecksValidator),
-        ]
-        for source, validator_cls in validators:
-            if source and (expanded := _expand_specs(source, resolved_all)):
-                pipeline.add(validator_cls(expanded))  # type: ignore[arg-type]
+        if dtypes := _expand_dtypes(spec.dtype_constraints, resolved_all):
+            pipeline.add(DtypeValidator(dtypes))
+        if non_nullable := _expand_columns(spec.non_nullable_columns, resolved_all):
+            pipeline.add(NullableValidator(non_nullable))
+        if unique := _expand_columns(spec.unique_columns, resolved_all):
+            pipeline.add(UniqueValidator(unique))
+        if checks := _expand_checks(spec.checks_by_column, resolved_all):
+            pipeline.add(ChecksValidator(checks))
 
         if strict:
             all_matched = set()

--- a/daffy/validators/columns.py
+++ b/daffy/validators/columns.py
@@ -52,8 +52,6 @@ def _dtype_matches(actual: Any, expected: Any) -> bool:
     expected_norm = _normalize_dtype(expected)
     if actual_norm == expected_norm:
         return True
-    if "(" in expected_norm:
-        return False
     return _base_dtype(actual_norm) == expected_norm
 
 

--- a/daffy/validators/pipeline.py
+++ b/daffy/validators/pipeline.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from daffy.validators.base import SkippableValidator, Validator
-
 if TYPE_CHECKING:
+    from daffy.validators.base import Validator
     from daffy.validators.context import ValidationContext
 
 
@@ -25,9 +24,6 @@ class ValidationPipeline:
         all_errors: list[str] = []
 
         for validator in self.validators:
-            if isinstance(validator, SkippableValidator) and validator.should_skip(ctx):
-                continue
-
             errors = validator.validate(ctx)
 
             if errors:

--- a/daffy/validators/rows.py
+++ b/daffy/validators/rows.py
@@ -65,7 +65,10 @@ class RowValidator:
         ctx: ValidationContext,
     ) -> str:
         count_prefix = "at least " if terminated_early else ""
-        lines = [f"Row validation failed for {count_prefix}{total_errors} out of {ctx.row_count} rows:", ""]
+        lines = [
+            f"Row validation failed for {count_prefix}{total_errors} out of {ctx.row_count} rows{ctx.param_info}:",
+            "",
+        ]
 
         for idx, error in failed_rows:
             lines.append(f"  Row {idx}:")
@@ -74,7 +77,11 @@ class RowValidator:
                 lines.append(f"    - {field}: {err['msg']}" if field else f"    - {err['msg']}")
             lines.append("")
 
-        if total_errors > len(failed_rows):
+        if terminated_early:
+            # Counting stopped at the break, so the remaining total is unknown. Saying
+            # "and 1 more" here read as "6 bad rows out of 10000" when every row failed.
+            lines.append(f"  ... stopped after {len(failed_rows)} reported rows; more rows may have errors")
+        elif total_errors > len(failed_rows):
             lines.append(f"  ... and {total_errors - len(failed_rows)} more row(s) with errors")
 
-        return "\n".join(lines) + ctx.param_info
+        return "\n".join(lines)

--- a/daffy/validators/spec_parser.py
+++ b/daffy/validators/spec_parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -73,7 +74,7 @@ def _parse_list_spec(columns: Sequence[Any], result: ParsedColumnSpec, strict_sp
         result.required_columns.append(col_name)
 
 
-def _parse_dict_spec(columns: dict[Any, Any], result: ParsedColumnSpec, strict_specs: bool) -> None:
+def _parse_dict_spec(columns: Mapping[str, Any], result: ParsedColumnSpec, strict_specs: bool) -> None:
     """Parse a dict column specification."""
     for index, (col_spec, value) in enumerate(columns.items()):
         col_name = _get_col_name(col_spec)
@@ -92,7 +93,9 @@ def _parse_dict_spec(columns: dict[Any, Any], result: ParsedColumnSpec, strict_s
             result.dtype_constraints[col_name] = value
 
 
-def parse_column_spec(columns: Sequence[Any] | dict[Any, Any] | None, strict_specs: bool = False) -> ParsedColumnSpec:
+def parse_column_spec(
+    columns: Sequence[Any] | Mapping[str, Any] | None, strict_specs: bool = False
+) -> ParsedColumnSpec:
     """Parse user-provided column specification into validator-ready format.
 
     Handles:
@@ -110,12 +113,12 @@ def parse_column_spec(columns: Sequence[Any] | dict[Any, Any] | None, strict_spe
     if columns is None:
         return result
 
-    if isinstance(columns, dict):
+    if isinstance(columns, Mapping):
         _parse_dict_spec(columns, result, strict_specs)
     elif isinstance(columns, str):
         # Treat a single string as a single column name, not a character sequence
         _parse_list_spec([columns], result, strict_specs)
     else:
-        _parse_list_spec(columns, result, strict_specs)
+        _parse_list_spec(list(columns), result, strict_specs)
 
     return result

--- a/daffy/validators/spec_parser.py
+++ b/daffy/validators/spec_parser.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from daffy.validation import ColumnConstraints
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -27,6 +29,24 @@ class ParsedColumnSpec:
         return self.required_columns + self.optional_columns
 
 
+CONSTRAINT_KEYS: frozenset[str] = frozenset(ColumnConstraints.__annotations__)
+
+
+def assert_known_constraints(col_name: str, constraints: dict[str, Any]) -> None:
+    """Reject constraint keys daffy does not implement.
+
+    A typo like `{"nullabel": False}` used to be accepted and then do nothing, which
+    means a guard the user believes is in place never runs. Deriving the valid set from
+    ColumnConstraints keeps this list from drifting out of sync with the TypedDict.
+    """
+    unknown = set(constraints) - CONSTRAINT_KEYS
+    if unknown:
+        valid = ", ".join(sorted(CONSTRAINT_KEYS))
+        raise ValueError(
+            f"Unknown constraint(s) {sorted(unknown)} for column '{col_name}'. Valid constraints are: {valid}"
+        )
+
+
 def _get_col_name(col_spec: Any) -> str | None:
     """Get column name from specification, or None if invalid.
 
@@ -44,6 +64,8 @@ def _get_col_name(col_spec: Any) -> str | None:
 
 def _parse_dict_constraints(col_name: str, constraints: dict[str, Any], result: ParsedColumnSpec) -> None:
     """Parse a dict constraint specification for a column."""
+    assert_known_constraints(col_name, constraints)
+
     is_required = constraints.get("required", True)
     if is_required:
         result.required_columns.append(col_name)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -9,7 +9,7 @@ You can use regex patterns to match column names that follow a specific pattern.
 Define a regex pattern by using the format `"r/pattern/"`:
 
 ```python
-@df_in(["Brand", "r/Price_\d+/"])
+@df_in(["Brand", r"r/Price_\d+/"])
 def process_data(df):
     # This will accept DataFrames with columns like "Brand", "Price_1", "Price_2", etc.
     ...
@@ -37,7 +37,7 @@ Regex patterns are also considered in strict mode. Any column matching a regex p
 You can use regex patterns in dictionaries that specify data types as well:
 
 ```python
-@df_in({"Brand": "object", "r/Price_\d+/": "int64"})
+@df_in({"Brand": "object", r"r/Price_\d+/": "int64"})
 def process_data(df):
     # This will check that all columns matching "Price_\d+" have int64 dtype
     ...
@@ -401,7 +401,7 @@ def process_data(df):
 The dictionary key becomes the check name in error messages:
 
 ```
-AssertionError: Column 'price' failed check 'no_outliers': 3 values failed. Examples: [50000, 99999]
+AssertionError: Column 'price' in function 'process_data' parameter 'df' failed check no_outliers: 3 values failed. Examples: [50000.0, 99999.0, 99999.0]
 ```
 
 Custom checks can use any Narwhals Series operations:
@@ -513,7 +513,7 @@ Row validation includes an early termination optimization. When validation error
 
 For example, validating 100k rows with early errors takes ~1.2ms instead of ~140ms.
 
-This optimization is enabled by default. Error messages will show "X out of Y+ rows" when early termination occurs, indicating there may be additional errors beyond those displayed.
+This optimization is enabled by default. Error messages read `Row validation failed for at least N out of M rows` when early termination occurs, and say that counting stopped rather than reporting a specific remainder, indicating there may be additional errors beyond those displayed.
 
 ### Advanced Features
 
@@ -561,9 +561,9 @@ When multiple validations fail, the error message includes all issues:
 ```
 Missing columns: ['category'] in function 'process_order' parameter 'df'. Got columns: ['price', 'quantity']
 
-Column 'price' contains 2 null values but nullable=False
+Column 'price' in function 'process_order' parameter 'df' contains 2 null values but nullable=False
 
-Column 'quantity' failed check gt: 1 values failed. Examples: [-5]
+Column 'quantity' in function 'process_order' parameter 'df' failed check gt: 1 values failed. Examples: [-5]
 ```
 
 This is useful for debugging when a DataFrame has multiple issues.
@@ -577,9 +577,25 @@ All configuration options can be set in `pyproject.toml`:
 strict = true                    # Enable strict mode by default
 lazy = true                      # Collect all errors before raising (default: false)
 allow_empty = false              # Reject empty DataFrames by default (default: true)
+strict_specs = true              # Raise TypeError on invalid column keys or spec types (default: false)
 row_validation_max_errors = 5    # Max failed rows to show (default: 5)
 checks_max_samples = 5           # Max sample values in check errors (default: 5)
 ```
+
+### strict_specs
+
+By default, a column key that is not a string or regex pattern is skipped. With
+`strict_specs = true` it raises `TypeError` instead:
+
+```python
+@df_in({"price": "float64", 123: "int64"})   # the 123 key is ignored by default
+def process_data(df):
+    ...
+```
+
+This covers the _shape_ of a spec. Misspelled constraint names (`{"nullabel": False}`), non-boolean
+constraint values (`{"nullable": "False"}`) and unknown check names (`{"checks": {"gtt": 0}}`) are
+always rejected when the decorator is applied, regardless of this setting.
 
 ### allow_empty
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -135,7 +135,7 @@ def process(df):
 @df_log(include_dtypes=True)
 def process(df):
     return df
-# Logs: ... columns: ['a', 'b'] with dtypes ['int64', 'object']
+# Logs: ... columns: ['a', 'b'] with dtypes [Int64, String]
 ```
 
 ---
@@ -192,6 +192,24 @@ columns={
 }
 ```
 
+Those five are the only valid constraint names. A misspelling such as `{"nullabel": False}` used to
+be accepted and then do nothing; it now raises `ValueError` when the decorator is applied.
+`nullable`, `unique` and `required` must be `True` or `False` — `"False"` is a string, and is
+rejected rather than ignored.
+
+For editor and type-checker support, annotate specs with `ColumnConstraints`, which catches the same
+typos statically:
+
+```python
+from daffy import ColumnConstraints
+
+SPEC: dict[str, ColumnConstraints] = {"price": {"nullable": False, "checks": {"gt": 0}}}
+
+@df_in(SPEC)
+def process_data(df):
+    ...
+```
+
 ### Regex Patterns
 
 Match multiple columns with regex:
@@ -230,6 +248,11 @@ Custom checks are also supported by passing a callable as the check value. A cal
 name; a non-callable value must name one of the built-in checks above, and a name that matches
 neither is rejected when the decorator is applied rather than on the first call.
 
+A check is also rejected if it cannot mean anything on the column's dtype — an ordering check
+(`gt`, `ge`, `lt`, `le`, `between`) on a string column, or a `str_*` check on a non-string column.
+Backends disagreed about these: some raised their own error while Polars compared strings
+lexicographically and reported a violation that looked real.
+
 `str_regex` applies your pattern as written: it matches anywhere in the value unless you anchor it
 yourself. Use `r"^\d+"` to require a match at the start and `r"^\d+$"` to require a full match.
 
@@ -263,9 +286,15 @@ Configure Daffy in `pyproject.toml`:
 
 ```toml
 [tool.daffy]
-strict = false                 # Default strict mode (default: false)
-row_validation_max_errors = 5  # Max errors shown in row validation (default: 5)
+strict = false                 # Reject unexpected columns (default: false)
+lazy = false                   # Collect all errors before raising (default: false)
+allow_empty = true             # Allow DataFrames with no rows (default: true)
+strict_specs = false           # Raise TypeError on invalid column keys or spec types (default: false)
+row_validation_max_errors = 5  # Max failed rows shown in row validation (default: 5)
 checks_max_samples = 5         # Max sample values in check errors (default: 5)
 ```
 
-Configuration is read from the `pyproject.toml` in the current working directory or any parent directory.
+Configuration is read from the `pyproject.toml` in the current working directory or any parent
+directory. Discovery starts at the process working directory, not at your module, so running the
+same code from a different directory can pick up a different configuration — worth knowing in a
+monorepo, or when a service runs with a `WORKDIR` that differs from your development checkout.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ parameter 'df'. Got columns: ['name', 'price']
 ```
 
 ```
-AssertionError: Column 'price' in function 'process_orders' parameter 'df'
+AssertionError: Column price in function 'process_orders' parameter 'df'
 has wrong dtype. Was int64, expected float64
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,8 +156,8 @@ Function filter_cars returned a DataFrame: columns: ['Brand', 'Price']
 or with `@df_log(include_dtypes=True)` you get:
 
 ```
-Function filter_cars parameters contained a DataFrame: columns: ['Brand', 'Price'] with dtypes ['object', 'int64']
-Function filter_cars returned a DataFrame: columns: ['Brand', 'Price'] with dtypes ['object', 'int64']
+Function filter_cars parameters contained a DataFrame: columns: ['Brand', 'Price'] with dtypes [String, Int64]
+Function filter_cars returned a DataFrame: columns: ['Brand', 'Price'] with dtypes [String, Int64]
 ```
 
 ## Next Steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daffy"
-version = "3.0.0"
+version = "3.1.0"
 description = "Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow."
 authors = [
  { name="Janne Sinivirta", email="janne.sinivirta@gmail.com" },

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -526,3 +526,47 @@ class TestBuiltinCheckNamesStayInSync:
         assert "gtt" not in BUILTIN_CHECK_NAMES
         with pytest.raises(ValueError, match="Unknown check"):
             apply_check(pd.Series([1]), "gtt", 0)
+
+
+class TestChecksRejectMismatchedDtypes:
+    """A check that cannot mean what the caller intended is an error, not a guess.
+
+    Backends disagreed here: Pandas and PyArrow raised their own errors while Polars
+    coerced the bound to a string and compared lexicographically, reporting '10' as
+    failing `gt: 5` in a message indistinguishable from a real violation.
+    """
+
+    @pytest.mark.parametrize("backend", STRING_BACKENDS)
+    @pytest.mark.parametrize("check_name", ["gt", "ge", "lt", "le", "between"])
+    def test_ordering_check_on_string_column_is_rejected(self, backend: str, check_name: str) -> None:
+        series = strings_with_null(backend)
+        value = (0, 9) if check_name == "between" else 5
+        with pytest.raises(ValueError, match="compares order"):
+            apply_check(series, check_name, value)
+
+    @pytest.mark.parametrize("backend", NUMERIC_BACKENDS)
+    @pytest.mark.parametrize(
+        ("check_name", "check_value"),
+        [("str_regex", r"\d+"), ("str_startswith", "1"), ("str_contains", "1"), ("str_length", (1, 5))],
+    )
+    def test_string_check_on_numeric_column_is_rejected(self, backend: str, check_name: str, check_value: Any) -> None:
+        with pytest.raises(ValueError, match="needs a string column"):
+            apply_check(numeric_with_null(backend), check_name, check_value)
+
+    def test_all_null_column_is_not_second_guessed(self) -> None:
+        """Pandas reports an all-null object column as String; that must not trip the guard."""
+        fail_count, _samples = apply_check(pd.Series([None, None, None]), "gt", 0)
+        assert fail_count == 3
+
+    def test_numeric_dtype_is_trusted_even_when_empty(self) -> None:
+        """An empty Float64 column still has a reliable dtype, unlike an all-null object column."""
+        with pytest.raises(ValueError, match="needs a string column"):
+            apply_check(pd.Series([], dtype=float), "str_regex", r"\d+")
+
+    def test_empty_string_column_accepts_string_checks(self) -> None:
+        fail_count, _samples = apply_check(pd.Series([], dtype="string"), "str_regex", r"\d+")
+        assert fail_count == 0
+
+    def test_backend_failure_is_wrapped_with_context(self) -> None:
+        with pytest.raises(ValueError, match="Check 'between' could not run"):
+            apply_check(pd.Series([1, 2, 3]), "between", 5)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -343,3 +343,16 @@ def test_get_config_uses_cache_for_same_cwd(tmp_path: Path) -> None:
 def test_get_int_config_invalid_override() -> None:
     with pytest.raises(ValueError, match="must be >="):
         get_checks_max_samples(0)
+
+
+def test_boolean_is_not_accepted_for_an_integer_setting(tmp_path: Path) -> None:
+    """Bool is a subclass of int, so the loader guards against it explicitly."""
+    write_pyproject(tmp_path, "row_validation_max_errors = true")
+
+    with patch("daffy.config.Path.cwd", return_value=tmp_path):
+        from daffy.config import load_config
+
+        clear_config_cache()
+
+        with pytest.raises(TypeError, match="must be an integer, got bool"):
+            load_config()

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -587,3 +587,52 @@ def test_df_in_string_positional_still_works(df: IntoDataFrame) -> None:
         return my_input
 
     test_fn(df)
+
+
+class TestUnnamedDfInPicksTheFirstFrame:
+    """An unnamed @df_in validates the first DataFrame it finds, args before kwargs."""
+
+    def test_first_positional_frame_wins(self) -> None:
+        @df_in(["A"])
+        def process(first: Any, second: Any) -> Any:
+            return first
+
+        with pytest.raises(AssertionError, match=r"Missing columns: \['A'\].*parameter 'first'"):
+            process(pd.DataFrame({"Z": [1]}), pd.DataFrame({"A": [1]}))
+
+    def test_positional_frame_is_preferred_over_keyword_frame(self) -> None:
+        @df_in(["A"])
+        def process(first: Any, second: Any = None) -> Any:
+            return first
+
+        with pytest.raises(AssertionError, match=r"parameter 'first'"):
+            process(pd.DataFrame({"Z": [1]}), second=pd.DataFrame({"A": [1]}))
+
+    def test_non_frame_arguments_are_skipped(self) -> None:
+        @df_in(["A"])
+        def process(config: dict[str, int], frame: Any) -> Any:
+            return frame
+
+        assert process({"k": 1}, pd.DataFrame({"A": [1]})) is not None
+
+
+class TestLazyFramesAreRejected:
+    def test_polars_lazyframe_is_not_accepted(self) -> None:
+        """eager_only=True; without it a LazyFrame is accepted and explodes later on .shape."""
+
+        @df_in(["a"])
+        def process(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match=r"Wrong parameter type.*got LazyFrame instead"):
+            process(pl.LazyFrame({"a": [1]}))
+
+
+class TestDtypeAliases:
+    @pytest.mark.parametrize(("alias", "frame"), [("bool", {"flag": [True, False]}), ("boolean", {"flag": [True]})])
+    def test_bool_alias_is_accepted(self, alias: str, frame: dict[str, Any]) -> None:
+        @df_in({"flag": alias})
+        def process(df: Any) -> Any:
+            return df
+
+        assert process(pd.DataFrame(frame)) is not None

--- a/tests/test_df_in.py
+++ b/tests/test_df_in.py
@@ -246,7 +246,7 @@ def test_multiple_named_inputs_without_names_in_function_call(
 ) -> None:
     @df_in(name="cars", columns=["Brand", "Price"], strict=True)
     @df_in(name="ext_cars", columns=["Brand", "Price", "Year"], strict=True)
-    def test_fn(cars: pd.DataFrame, ext_cars: pd.DataFrame) -> int:
+    def test_fn(cars: IntoDataFrame, ext_cars: IntoDataFrame) -> int:
         return len(cars) + len(ext_cars)
 
     test_fn(basic_df, extended_df)

--- a/tests/test_df_in_row_validation.py
+++ b/tests/test_df_in_row_validation.py
@@ -149,3 +149,28 @@ class TestMaxErrorsBoundary:
         message = self._run_with_bad_rows(10000)
         assert "and 1 more row(s)" not in message
         assert "more rows may have errors" in message
+
+
+class TestValidatorConstructorArguments:
+    """RowValidator and ChecksValidator advertise these, but nothing ever passed them."""
+
+    def test_row_validator_max_errors_overrides_config(self) -> None:
+        from daffy.validators.context import ValidationContext
+        from daffy.validators.rows import RowValidator
+
+        ctx = ValidationContext(df=pd.DataFrame({"v": ["x"] * 8}))
+        errors = RowValidator(PersonValidator, max_errors=2).validate(ctx)
+
+        assert len(errors) == 1
+        assert errors[0].count("  Row ") == 2, "config default is 5, so the argument must win"
+        assert errors[0].startswith("Row validation failed for at least 3 out of 8 rows")
+
+    def test_checks_validator_max_samples_overrides_config(self) -> None:
+        from daffy.validators.checks import ChecksValidator
+        from daffy.validators.context import ValidationContext
+
+        ctx = ValidationContext(df=pd.DataFrame({"v": [-1] * 10}))
+        errors = ChecksValidator({"v": {"gt": 0}}, max_samples=2).validate(ctx)
+
+        assert len(errors) == 1
+        assert "Examples: [-1, -1]" in errors[0], "config default is 5, so the argument must win"

--- a/tests/test_df_in_row_validation.py
+++ b/tests/test_df_in_row_validation.py
@@ -134,9 +134,18 @@ class TestMaxErrorsBoundary:
     def test_lists_every_failing_row_up_to_the_limit(self) -> None:
         message = self._run_with_bad_rows(5)
         assert message.count("  Row ") == 5
-        assert message.startswith("Row validation failed for 5 out of 5 rows:")
+        assert message.startswith("Row validation failed for 5 out of 5 rows in function")
+        assert "more row" not in message
+        assert "stopped after" not in message
 
     def test_stops_listing_past_the_limit(self) -> None:
         message = self._run_with_bad_rows(8)
         assert message.count("  Row ") == 5
         assert "at least" in message
+        assert "stopped after 5 reported rows" in message
+
+    def test_does_not_understate_how_many_rows_failed(self) -> None:
+        """Counting stops at the break, so the trailer must not claim a specific remainder."""
+        message = self._run_with_bad_rows(10000)
+        assert "and 1 more row(s)" not in message
+        assert "more rows may have errors" in message

--- a/tests/test_df_in_row_validation.py
+++ b/tests/test_df_in_row_validation.py
@@ -174,3 +174,15 @@ class TestValidatorConstructorArguments:
 
         assert len(errors) == 1
         assert "Examples: [-1, -1]" in errors[0], "config default is 5, so the argument must win"
+
+
+def test_row_validator_without_early_termination_counts_every_failure() -> None:
+    """With early_termination off the loop runs to the end, so the remainder is exact."""
+    from daffy.validators.context import ValidationContext
+    from daffy.validators.rows import RowValidator
+
+    ctx = ValidationContext(df=pd.DataFrame({"v": ["x"] * 8}))
+    errors = RowValidator(PersonValidator, max_errors=2, early_termination=False).validate(ctx)
+
+    assert errors[0].startswith("Row validation failed for 8 out of 8 rows")
+    assert "... and 6 more row(s) with errors" in errors[0]

--- a/tests/test_df_log.py
+++ b/tests/test_df_log.py
@@ -13,7 +13,7 @@ from tests.conftest import IntoDataFrame, cars
 @pytest.mark.parametrize(("df"), [pd.DataFrame(cars), pl.DataFrame(cars)])
 def test_log_df(df: IntoDataFrame, mocker: MockerFixture) -> None:
     @df_log()
-    def test_fn(foo_df: pd.DataFrame) -> pd.DataFrame:
+    def test_fn(foo_df: IntoDataFrame) -> IntoDataFrame:
         return foo_df
 
     mock_log = mocker.patch("daffy.decorators.logging.log")

--- a/tests/test_lazy_validation.py
+++ b/tests/test_lazy_validation.py
@@ -224,3 +224,29 @@ class TestLazyValidationErrorMessages:
         # Each error type should be on its own line(s)
         lines = error.split("\n\n")
         assert len(lines) == 3  # missing, nullable, unique
+
+
+class TestLazyCollectsEveryErrorFromOneValidator:
+    """Lazy mode was only ever exercised across different validators, never within one."""
+
+    def test_all_dtype_mismatches_are_reported(self) -> None:
+        @df_in({"a": "int64", "b": "int64", "c": "int64"}, lazy=True)
+        def process(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError) as exc_info:
+            process(pd.DataFrame({"a": ["x"], "b": ["y"], "c": ["z"]}))
+
+        message = str(exc_info.value)
+        for column in ("a", "b", "c"):
+            assert f"Column {column}" in message
+
+    def test_eager_mode_reports_the_first_failing_validator(self) -> None:
+        """Shape runs before columns, so an empty frame reports allow_empty, not min_rows."""
+
+        @df_in(exact_rows=9, min_rows=5, allow_empty=False)
+        def process(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match="allow_empty=False"):
+            process(pd.DataFrame({"a": []}))

--- a/tests/test_typing_contract.py
+++ b/tests/test_typing_contract.py
@@ -1,0 +1,69 @@
+"""Typing contracts that the pyrefly gate enforces.
+
+These assertions are mostly static: the value is that `pyrefly check .` fails if the
+decorators stop preserving signatures, or if ColumnsDef goes back to a key type that
+only accepts inline dict literals.
+"""
+
+from typing import Any
+
+import pandas as pd
+
+from daffy import df_in, df_log, df_out
+from daffy.validation import ColumnConstraints
+
+# Specs built once and shared, rather than inlined at each decorator. dict keys are
+# invariant, so a narrower ColumnsDef key type rejects every one of these.
+DTYPE_SPEC: dict[str, str] = {"price": "float64"}
+RICH_SPEC: dict[str, ColumnConstraints] = {"price": {"nullable": False, "checks": {"gt": 0}}}
+COLUMN_LIST: list[str] = ["price"]
+
+
+@df_in(DTYPE_SPEC)
+def with_dtype_spec(df: Any) -> Any:
+    return df
+
+
+@df_in(RICH_SPEC)
+def with_rich_spec(df: Any) -> Any:
+    return df
+
+
+@df_out(DTYPE_SPEC)
+def returning_dtype_spec() -> pd.DataFrame:
+    return pd.DataFrame({"price": [1.0]})
+
+
+@df_in(COLUMN_LIST)
+def with_column_list(df: Any) -> Any:
+    return df
+
+
+@df_in(["price"])
+def keeps_its_signature(df: Any, rate: float, *, label: str = "x") -> str:
+    return f"{label}{rate}"
+
+
+@df_log()
+def logged(df: Any, count: int) -> int:
+    return count
+
+
+def test_shared_specs_work_at_runtime_too() -> None:
+    df = pd.DataFrame({"price": [1.0]})
+
+    assert with_dtype_spec(df) is df
+    assert with_rich_spec(df) is df
+    assert with_column_list(df) is df
+    assert returning_dtype_spec() is not None
+
+
+def test_decorated_functions_keep_their_signature() -> None:
+    from inspect import signature
+
+    assert list(signature(keeps_its_signature).parameters) == ["df", "rate", "label"]
+    assert list(signature(logged).parameters) == ["df", "count"]
+
+    df = pd.DataFrame({"price": [1.0]})
+    assert keeps_its_signature(df, 1.5, label="n") == "n1.5"
+    assert logged(df, 3) == 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,12 @@
 """Tests for utility functions."""
 
+import logging
 from typing import Any
 
 import pandas as pd
 import pytest
 
+from daffy import df_in, df_log, df_out
 from daffy.utils import ParameterResolver
 
 
@@ -95,3 +97,62 @@ def test_get_parameter_unnamed_falls_back_when_varkwargs_have_no_dataframe() -> 
 
     parameter_name = ParameterResolver(func).resolve(None, "metadata", retries=3, verbose=True)[1]
     assert parameter_name == "meta"
+
+
+class TestDuplicateColumnNames:
+    """Narwhals rejects duplicate column names with DuplicateError, a ValueError.
+
+    That used to escape every decorator uncaught, turning @df_log - which only logs -
+    into something that broke a working function.
+    """
+
+    @staticmethod
+    def _duplicated() -> pd.DataFrame:
+        return pd.DataFrame([[1, 2]], columns=["A", "A"])
+
+    def test_df_in_reports_it_as_a_validation_error(self) -> None:
+        @df_in(["A"])
+        def process(df: Any) -> Any:
+            return df
+
+        with pytest.raises(AssertionError, match="Cannot validate this DataFrame"):
+            process(self._duplicated())
+
+    def test_df_out_reports_it_as_a_validation_error(self) -> None:
+        @df_out(["A"])
+        def produce() -> Any:
+            return TestDuplicateColumnNames._duplicated()
+
+        with pytest.raises(AssertionError, match="Cannot validate this DataFrame"):
+            produce()
+
+    def test_df_log_does_not_break_the_function(self, caplog: pytest.LogCaptureFixture) -> None:
+        @df_log()
+        def summarize(df: Any) -> Any:
+            return df.iloc[:, [0]]
+
+        with caplog.at_level(logging.WARNING):
+            result = summarize(self._duplicated())
+
+        assert result.shape == (1, 1)
+        assert "could not be described" in caplog.text
+
+
+class TestParameterNamesPastVarargs:
+    """param_names includes keyword-only names, so indexing it by position misreports."""
+
+    def test_frame_in_varargs_is_named_as_varargs(self) -> None:
+        @df_in(columns=["missing"])
+        def process(first: Any, *rest: Any, flag: bool = False) -> Any:
+            return rest
+
+        with pytest.raises(AssertionError, match=r"parameter 'rest'"):
+            process(1, 2, pd.DataFrame({"x": [1]}))
+
+    def test_frame_in_varargs_only_signature(self) -> None:
+        @df_in(columns=["missing"])
+        def process(*frames: Any, **opts: Any) -> Any:
+            return frames
+
+        with pytest.raises(AssertionError, match=r"parameter 'frames'"):
+            process(1, pd.DataFrame({"x": [1]}))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -156,3 +156,11 @@ class TestParameterNamesPastVarargs:
 
         with pytest.raises(AssertionError, match=r"parameter 'frames'"):
             process(1, pd.DataFrame({"x": [1]}))
+
+
+def test_describe_dataframe_rejects_a_non_dataframe() -> None:
+    from daffy.narwhals_compat import UnsupportedDataFrameError
+    from daffy.utils import describe_dataframe
+
+    with pytest.raises(UnsupportedDataFrameError, match="not a supported DataFrame, got str"):
+        describe_dataframe("not a frame")

--- a/tests/test_value_checks_integration.py
+++ b/tests/test_value_checks_integration.py
@@ -413,3 +413,42 @@ class TestStrictWithoutColumnConstraints:
             return df
 
         assert process(pd.DataFrame({"a": [1], "price_eur": [1.0]})) is not None
+
+
+class TestConstraintKeysValidatedAtDecoration:
+    """A misspelled constraint used to be accepted and then do nothing at all."""
+
+    @pytest.mark.parametrize("decorator", [df_in, df_out])
+    @pytest.mark.parametrize("typo", ["nullabel", "uniqe", "dtpye", "requred"])
+    def test_unknown_constraint_is_rejected(self, decorator: Any, typo: str) -> None:
+        with pytest.raises(ValueError, match=f"Unknown constraint\\(s\\) \\['{typo}'\\] for column 'price'"):
+            decorator(columns={"price": {typo: False}})
+
+    def test_checks_written_without_the_checks_key_are_rejected(self) -> None:
+        """{"price": {"gt": 0}} looks reasonable but nests nothing under `checks`."""
+        with pytest.raises(ValueError, match="Unknown constraint"):
+            df_in(columns={"price": {"gt": 0}})
+
+    def test_error_lists_the_valid_constraints(self) -> None:
+        with pytest.raises(ValueError, match="dtype, nullable, required, unique"):
+            df_in(columns={"price": {"nope": 1}})
+
+    @pytest.mark.parametrize("constraint", ["nullable", "unique", "required"])
+    @pytest.mark.parametrize("bad_value", ["False", 0, 1, None])
+    def test_non_boolean_constraint_value_is_rejected(self, constraint: str, bad_value: Any) -> None:
+        with pytest.raises(TypeError, match=f"Constraint '{constraint}' for column 'price' must be True or False"):
+            df_in(columns={"price": {constraint: bad_value}})
+
+    def test_a_full_valid_spec_is_accepted(self) -> None:
+        @df_in(columns={"price": {"dtype": "int64", "nullable": False, "unique": True, "checks": {"gt": 0}}})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        assert to_list(process(pd.DataFrame({"price": [1, 2]}))["price"]) == [1, 2]
+
+    def test_constraint_keys_come_from_the_typed_dict(self) -> None:
+        """The valid set is derived, so it cannot drift from ColumnConstraints."""
+        from daffy.validation import ColumnConstraints
+        from daffy.validators.spec_parser import CONSTRAINT_KEYS
+
+        assert set(ColumnConstraints.__annotations__) == CONSTRAINT_KEYS

--- a/tests/test_value_checks_integration.py
+++ b/tests/test_value_checks_integration.py
@@ -349,3 +349,67 @@ class TestCheckNamesValidatedAtDecoration:
     def test_non_dict_checks_left_to_runtime(self) -> None:
         """Malformed `checks` is a spec-shape problem, handled by strict_specs, not here."""
         df_in(columns={"price": {"checks": "nonsense"}})
+
+
+class TestOverlappingSpecs:
+    """Two specs can name the same column - a regex and an explicit name, or two regexes."""
+
+    def test_checks_from_both_specs_apply(self) -> None:
+        @df_in(columns={"r/^col/": {"checks": {"gt": 0}}, "col1": {"checks": {"lt": 100}}})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        with pytest.raises(AssertionError, match="gt"):
+            process(pd.DataFrame({"col1": [-5]}))
+        with pytest.raises(AssertionError, match="lt"):
+            process(pd.DataFrame({"col1": [500]}))
+        assert to_list(process(pd.DataFrame({"col1": [5]}))["col1"]) == [5]
+
+    def test_check_merging_does_not_depend_on_spec_order(self) -> None:
+        @df_in(columns={"col1": {"checks": {"lt": 100}}, "r/^col/": {"checks": {"gt": 0}}})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        with pytest.raises(AssertionError, match="gt"):
+            process(pd.DataFrame({"col1": [-5]}))
+
+    @pytest.mark.parametrize(("constraint", "value"), [("nullable", False), ("unique", True)])
+    def test_overlapping_column_constraints_do_not_duplicate(self, constraint: str, value: bool) -> None:
+        """A column matched by two specs must not produce a duplicate backend expression."""
+
+        @df_in(columns={"r/^col/": {constraint: value}, "col1": {constraint: value}})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        assert to_list(process(pd.DataFrame({"col1": [1, 2]}))["col1"]) == [1, 2]
+
+    def test_explicit_dtype_wins_over_regex_dtype(self) -> None:
+        @df_in(columns={"r/^col/": "int64", "col1": "float64"})
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        assert to_list(process(pd.DataFrame({"col1": [1.5]}))["col1"]) == [1.5]
+
+
+class TestStrictWithoutColumnConstraints:
+    def test_empty_spec_with_strict_rejects_every_column(self) -> None:
+        @df_in([], strict=True)
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        with pytest.raises(AssertionError, match="unexpected column"):
+            process(pd.DataFrame({"a": [1]}))
+
+    def test_empty_spec_with_strict_accepts_an_empty_frame(self) -> None:
+        @df_in([], strict=True)
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        assert process(pd.DataFrame()) is not None
+
+    def test_optional_regex_columns_are_allowed_under_strict(self) -> None:
+        @df_in({"a": {"required": True}, "r/^price_/": {"required": False}}, strict=True)
+        def process(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+        assert process(pd.DataFrame({"a": [1], "price_eur": [1.0]})) is not None

--- a/tests/validators/test_builder.py
+++ b/tests/validators/test_builder.py
@@ -366,3 +366,23 @@ class TestStrictSpecs:
                 allow_empty=True,
                 df_columns=["a"],
             )
+
+
+class TestOverlappingDtypeSpecs:
+    def test_first_regex_spec_wins_when_two_regexes_match(self) -> None:
+        pipeline = build_validation_pipeline(
+            columns={"r/^col/": "int64", "r/1$/": "float64"},
+            strict=False,
+            strict_specs=False,
+            lazy=False,
+            composite_unique=None,
+            row_validator=None,
+            min_rows=None,
+            max_rows=None,
+            exact_rows=None,
+            allow_empty=True,
+            df_columns=["col1"],
+        )
+
+        dtype_validator = next(v for v in pipeline.validators if isinstance(v, DtypeValidator))
+        assert dtype_validator.expected == {"col1": "int64"}

--- a/tests/validators/test_pipeline.py
+++ b/tests/validators/test_pipeline.py
@@ -91,36 +91,3 @@ class TestValidationPipeline:
 
         pipeline.add(AlwaysPassValidator())
         assert len(pipeline) == 2
-
-
-class TestSkippableValidator:
-    def test_skips_when_should_skip_returns_true(self) -> None:
-        @dataclass
-        class SkippableFailValidator:
-            def should_skip(self, ctx: ValidationContext) -> bool:  # noqa: ARG002
-                return True
-
-            def validate(self, ctx: ValidationContext) -> list[str]:  # noqa: ARG002
-                return ["Should not see this"]
-
-        ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
-        pipeline = ValidationPipeline()
-        pipeline.add(SkippableFailValidator())
-
-        pipeline.run(ctx)
-
-    def test_runs_when_should_skip_returns_false(self) -> None:
-        @dataclass
-        class NonSkippableFailValidator:
-            def should_skip(self, ctx: ValidationContext) -> bool:  # noqa: ARG002
-                return False
-
-            def validate(self, ctx: ValidationContext) -> list[str]:  # noqa: ARG002
-                return ["Expected error"]
-
-        ctx = ValidationContext(df=pd.DataFrame({"a": [1]}))
-        pipeline = ValidationPipeline()
-        pipeline.add(NonSkippableFailValidator())
-
-        with pytest.raises(AssertionError, match="Expected error"):
-            pipeline.run(ctx)

--- a/tests/validators/test_spec_parser.py
+++ b/tests/validators/test_spec_parser.py
@@ -1,8 +1,13 @@
 """Tests for column spec parsing."""
 
+from typing import Any
+
 import pytest
 
 from daffy.validators.spec_parser import parse_column_spec
+
+# Deliberately invalid: a non-string column key, which type checkers reject.
+INVALID_KEY_SPEC: Any = {"a": "int64", 123: "int64"}
 
 
 class TestParseColumnSpec:
@@ -96,10 +101,10 @@ class TestParseColumnSpec:
             parse_column_spec(["a", 123], strict_specs=True)
 
     def test_invalid_column_key_in_dict_is_ignored_by_default(self) -> None:
-        result = parse_column_spec({"a": "int64", 123: "int64"})
+        result = parse_column_spec(INVALID_KEY_SPEC)
         assert result.required_columns == ["a"]
         assert result.dtype_constraints == {"a": "int64"}
 
     def test_invalid_column_key_in_dict_raises_when_strict_specs_enabled(self) -> None:
         with pytest.raises(TypeError, match="Invalid column key at index 1"):
-            parse_column_spec({"a": "int64", 123: "int64"}, strict_specs=True)
+            parse_column_spec(INVALID_KEY_SPEC, strict_specs=True)


### PR DESCRIPTION
Six parallel audits (security, performance, usability, documentation, readability, correctness) against 3.0.0. Every finding below was reproduced independently before being acted on — three agents made at least one claim that did not survive checking, and those were dropped.

The correctness agent ran **142 mutations: 84 killed, 58 survived, 26 classified equivalent, 32 genuine gaps.**

## Validation that silently did not happen

**Overlapping specs dropped a constraint.** Two specs can name the same column — `"r/^price/"` and `"price_eur"` both match `price_eur`. `_expand_specs` overwrote, so the last one in the dict won:

```python
@df_in({"r/^col/": {"checks": {"gt": 0}}, "col1": {"checks": {"lt": 100}}})
process(pd.DataFrame({"col1": [-5]}))   # passed: the gt:0 check vanished
```

Swapping the keys made it fail correctly. `_expand_specs` was generic over the value type, which is exactly why it could not merge: dtypes conflict, checks should union, column lists should dedupe. Split into three functions that each know their own rule. The same overlap crashed `nullable`/`unique` with `DuplicateError`.

**`@df_in([], strict=True)` ignored `strict`** — `if columns:` skipped the block that adds `StrictModeValidator`.

**Misspelled constraints did nothing.** `{"nullabel": False}` was accepted and never validated anything, and `strict_specs=true` did not cover it. Nor did `{"nullable": "False"}`, because the parser tests identity against `True`/`False`. Both now raise at decoration, with the valid set derived from `ColumnConstraints` so the list cannot drift.

## Crashes outside the error contract

**Duplicate column names broke every decorator**, including `@df_log`, which is documented as pure logging:

```
undecorated works: (1, 1)
@df_log       → DuplicateError: Expected unique column names, got: 'A' 2 times
```

`DuplicateError` subclasses `ValueError`, so `except TypeError` missed it. Now `df_in`/`df_out` raise a clear `AssertionError` and `df_log` warns without breaking the call.

**A check on the wrong dtype gave three different answers.** Same spec, same data:

```
pandas   TypeError: '>' not supported between 'str' and 'int'
pyarrow  ArrowNotImplementedError: no kernel matching (string, int64)
polars   AssertionError: ... failed check gt: 2 values failed. Examples: ['10', '3']
```

Polars coerced `5` to `"5"` and compared lexicographically, reporting a violation indistinguishable from a real one. Ordering checks on string columns and `str_*` checks on non-string columns are now rejected identically everywhere. An all-null Pandas object column reads as `String`, so the guard skips columns with no values rather than raising a false alarm.

## Misleading output

**Row validation understated catastrophic failure.** 10,000 rows, every one failing: `at least 6 out of 10000 rows` plus `... and 1 more row(s)` — reads as 0.07% when the truth is 100%, because `total_errors` stops at the `break`. It now reports that counting stopped.

Errors past a `*args` boundary named the wrong parameter (`param_names` includes keyword-only names), and wrong-type errors did not name the function.

## Typing

Applying any decorator disabled argument checking at **every call site**. Identical file, one `@df_in` line added:

```
undecorated → 3 errors (bad-argument-type, missing-argument, unexpected-keyword)
decorated   → 0 errors
```

`ParamSpec` restores them. Separately, `ColumnsDef` used `dict[str | RegexColumnDef, Any]`; dict keys are invariant, so only inline literals type-checked — hoisting a spec to a constant failed, including `dict[str, ColumnConstraints]`, the very type documented as the defence against the constraint typos above. Fixing the erasure exposed three latent annotation errors in the test suite.

## Performance and dead weight

`SkippableValidator` had **zero implementations** in `daffy/` — only two throwaway classes in its own test — while `pipeline.run` paid a `runtime_checkable` `isinstance` per validator per call (3.16µs vs 0.024µs for `hasattr`). Deleted, taking `@df_in(columns=...)` from ~41µs to ~38µs.

## Tests

864 passing (was 775), coverage 98.97%. New coverage for lazy mode collecting multiple errors from one validator, `strict` + `required=False`, the unnamed-`df_in` first-frame rule, `eager_only` rejecting a `LazyFrame`, the `bool` alias the docs use, the `RowValidator(max_errors=)`/`ChecksValidator(max_samples=)` arguments no test ever passed, and the bool-is-not-an-int config guard.

## Docs

Every Python block in the docs already executed correctly (57 run, 53 clean, 4 environmental, 0 code defects) — the rot was in the quoted **output**: 5 of 18 blocks wrong, including `df_log` dtype lines still showing pandas-era strings and a `"X out of Y+ rows"` format that never existed. Also fixed three README links that 404'd, and documented `strict_specs`, three missing config keys, `ColumnConstraints`, and that config discovery follows the working directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter validation for column specifications, constraints, checks, duplicate columns, and overlapping specifications.
  * Added data-type compatibility checks with clearer validation errors.
  * Improved support for different dataframe types and preserved decorated function signatures.
  * Enhanced row-validation messages and lazy-validation error reporting.

* **Bug Fixes**
  * Improved handling of empty, all-null, and unsupported dataframe inputs.
  * Corrected dtype matching and backend error reporting.

* **Documentation**
  * Updated release notes, configuration guidance, examples, and documentation links for version 3.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->